### PR TITLE
Add nvm version display.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ Tide variables that users are encouraged to modify begin with the string `tide_`
 
 ## General Variables
 
-| Variable           | Description                                | Default                                      |
-| ------------------ | ------------------------------------------ | -------------------------------------------- |
-| newline            | add empty line before each prompt          | true                                         |
-| left_prompt_items  | order of the left prompt items to display  | pwd git_prompt newline prompt_char           |
-| right_prompt_items | order of the right prompt items to display | status cmd_duration context jobs virtual_env |
+| Variable           | Description                                | Default                                          |
+| ------------------ | ------------------------------------------ | ------------------------------------------------ |
+| newline            | add empty line before each prompt          | true                                             |
+| left_prompt_items  | order of the left prompt items to display  | pwd git_prompt newline prompt_char               |
+| right_prompt_items | order of the right prompt items to display | status cmd_duration context jobs virtual_env nvm |
 
 ### prompt_connection
 
@@ -155,6 +155,13 @@ Tide's git capabilities are inherited from fish's built-in [fish_git_prompt][]. 
 | virtual_env_color   | color of virtual_env item                                                                                                              | 00AFAF      |
 | virtual_env_icon    | icon to display in front of virtual_env item                                                                                           | ''         |
 | virtual_env_display | Options are venvName and projectName. venvName is the virtual env directory, most often .venv. projectName is the directory above that | projectName |
+
+### nvm
+
+| Variable      | Description                          | Default |
+| ------------- | ------------------------------------ | ------- |
+| nvm_env_color | color of nvm item                    | 00AFAF  |
+| nvm_env_icon  | icon to display in front of ncm item | ''     |
 
 ## Fonts
 

--- a/functions/_tide_item_nvm.fish
+++ b/functions/_tide_item_nvm.fish
@@ -1,0 +1,9 @@
+function _tide_item_nvm
+    test 
+    set -l node_version (functions -q nvm; and nvm current)
+
+    if test "$node_version" != "none" -a "$node_version" != "system" -a -n "$node_version"
+        set_color $tide_nvm_color
+        printf '%s ' "$tide_nvm_icon $node_version"
+    end
+end

--- a/tide_theme/configure/configs/lean.fish
+++ b/tide_theme/configure/configs/lean.fish
@@ -10,7 +10,7 @@ _set fake_tide_prompt_connection_icon ' '
 
 # --------------------Prompt Items--------------------
 _set fake_tide_left_prompt_items 'pwd' 'git_prompt' 'newline' 'prompt_char'
-_set fake_tide_right_prompt_items 'status' 'cmd_duration' 'context' 'jobs' 'virtual_env'
+_set fake_tide_right_prompt_items 'status' 'cmd_duration' 'context' 'jobs' 'virtual_env' 'nvm'
 # ------------Prompt Char------------
 _set fake_tide_prompt_char_success_color $_tide_color_green
 _set fake_tide_prompt_char_failure_color FF0000
@@ -61,6 +61,9 @@ _set fake_tide_jobs_color $tideColorDarkerGreen
 _set fake_tide_virtual_env_color 00AFAF
 _set fake_tide_virtual_env_display 'projectName'
 _set fake_tide_virtual_env_icon ''
+# ---------------NVM---------------
+_set fake_tide_nvm_color 22BB99
+_set fake_tide_nvm_icon ''
 # ---------------Time---------------
 _set fake_tide_time_color 5F8787
 _set fake_tide_time_format '%T'

--- a/tide_theme/configure/configs/pure.fish
+++ b/tide_theme/configure/configs/pure.fish
@@ -60,6 +60,9 @@ _set fake_tide_jobs_color $tideColorDarkerGreen
 _set fake_tide_virtual_env_color 00AFAF
 _set fake_tide_virtual_env_display 'projectName'
 _set fake_tide_virtual_env_icon ''
+# ---------------NVM---------------
+_set fake_tide_nvm_color 22BB99
+_set fake_tide_nvm_icon ''
 # ---------------Time---------------
 _set fake_tide_time_color 6C6C6C
 _set fake_tide_time_format '%T'

--- a/tide_theme/configure/prompt_items/_fake_tide_item_nvm.fish
+++ b/tide_theme/configure/prompt_items/_fake_tide_item_nvm.fish
@@ -1,0 +1,2 @@
+function _fake_tide_item_nvm
+end


### PR DESCRIPTION
The following test cases fails, would appreciate if you can help me out in testing these:
* pwd
* status

I have chosen a less distracting green for nvm, since nodejs's default icon color is green. Also I think default color of virtual_env item should be yellow since python is yellow IMHO.