### PR TITLE
Add nvm display to prompt.

### DIFF
--- a/functions/_tide_item_nvm.fish
+++ b/functions/_tide_item_nvm.fish
@@ -1,23 +1,15 @@
-function _tide_node_version
-    function top_level_dir --argument-names dirPath
-	echo (string split --max 2 / $dirPath)[2]
-    end
-
-    set -l node_path_begin (top_level_dir (which node 2>/dev/null))
-    set -l home_path_begin (top_level_dir $HOME)
-
-    if test $node_path_begin = $home_path_begin;
-	echo (node --version)
-    else;
-	echo "system"
-    end
-end
-
 function _tide_item_nvm
-    set -l node_version (_tide_node_version)
+    if set -l whichNode (which node 2>/dev/null) # Ensure node is installed
+        set -l nodeVersion (node --version)
 
-    if test "$node_version" != "system" -a -n "$node_version"
-        set_color $tide_nvm_color
-        printf '%s ' "$tide_nvm_icon $node_version"
+        if test -n "$tide_nvm_default_node"
+            if test "$tide_nvm_default_node" != "$nodeVersion"
+                set_color $tide_nvm_color
+                printf '%s' {$tide_nvm_icon}' ' $nodeVersion
+            end
+        else if string match --quiet --regex "^$NVM_DIR.*" $whichNode # If node path begins with nvm directory
+            set_color $tide_nvm_color
+            printf '%s' $tide_nvm_icon' ' $nodeVersion
+        end
     end
 end

--- a/functions/_tide_item_nvm.fish
+++ b/functions/_tide_item_nvm.fish
@@ -1,6 +1,6 @@
 function _tide_item_nvm
     if set -l whichNode (which node 2>/dev/null) # Ensure node is installed
-        set -l nodeVersion (node --version)
+        set -l nodeVersion (string split / $whichNode)[-3] # Much faster than node --version
 
         if test -n "$tide_nvm_default_node"
             if test "$tide_nvm_default_node" != "$nodeVersion"

--- a/functions/_tide_item_nvm.fish
+++ b/functions/_tide_item_nvm.fish
@@ -1,0 +1,23 @@
+function _tide_node_version
+    function top_level_dir --argument-names dirPath
+	echo (string split --max 2 / $dirPath)[2]
+    end
+
+    set -l node_path_begin (top_level_dir (which node 2>/dev/null))
+    set -l home_path_begin (top_level_dir $HOME)
+
+    if test $node_path_begin = $home_path_begin;
+	echo (node --version)
+    else;
+	echo "system"
+    end
+end
+
+function _tide_item_nvm
+    set -l node_version (_tide_node_version)
+
+    if test "$node_version" != "system" -a -n "$node_version"
+        set_color $tide_nvm_color
+        printf '%s ' "$tide_nvm_icon $node_version"
+    end
+end

--- a/tide_theme/configure/configs/classic.fish
+++ b/tide_theme/configure/configs/classic.fish
@@ -61,7 +61,7 @@ tide_right_prompt_frame_enabled true
 tide_right_prompt_item_separator_diff_color ''
 tide_right_prompt_item_separator_same_color ''
 tide_right_prompt_item_separator_same_color_color 949494
-tide_right_prompt_items 'status' 'cmd_duration' 'context' 'jobs' 'virtual_env'
+tide_right_prompt_items 'status' 'cmd_duration' 'context' 'jobs' 'nvm' 'virtual_env'
 tide_right_prompt_pad_items true
 tide_right_prompt_prefix ''
 tide_right_prompt_suffix ''
@@ -83,3 +83,5 @@ tide_virtual_env_bg_color 444444
 tide_virtual_env_color 00AFAF
 tide_virtual_env_display_mode 'projectName'
 tide_virtual_env_icon ''
+tide_nvm_color 00AFAF
+tide_nvm_icon ''

--- a/tide_theme/configure/configs/classic.fish
+++ b/tide_theme/configure/configs/classic.fish
@@ -36,6 +36,9 @@ tide_left_prompt_items 'pwd' 'git_prompt' 'newline'
 tide_left_prompt_pad_items true
 tide_left_prompt_prefix ''
 tide_left_prompt_suffix ''
+tide_nvm_color 00AFAF
+tide_nvm_default_node
+tide_nvm_icon '⬢'
 tide_os_bg_color 444444
 tide_os_color EEEEEE
 tide_os_use_nearest true
@@ -83,5 +86,3 @@ tide_virtual_env_bg_color 444444
 tide_virtual_env_color 00AFAF
 tide_virtual_env_display_mode 'projectName'
 tide_virtual_env_icon ''
-tide_nvm_color 00AFAF
-tide_nvm_icon ''

--- a/tide_theme/configure/configs/lean.fish
+++ b/tide_theme/configure/configs/lean.fish
@@ -36,6 +36,9 @@ tide_left_prompt_items 'pwd' 'git_prompt' 'newline' 'prompt_char'
 tide_left_prompt_pad_items false
 tide_left_prompt_prefix ''
 tide_left_prompt_suffix ' '
+tide_nvm_color 00AFAF
+tide_nvm_default_node
+tide_nvm_icon '⬢'
 tide_os_bg_color normal
 tide_os_color normal
 tide_os_use_nearest true
@@ -83,5 +86,3 @@ tide_virtual_env_bg_color normal
 tide_virtual_env_color 00AFAF
 tide_virtual_env_display_mode 'projectName'
 tide_virtual_env_icon ''
-tide_nvm_color 00AFAF
-tide_nvm_icon ''

--- a/tide_theme/configure/configs/lean.fish
+++ b/tide_theme/configure/configs/lean.fish
@@ -61,7 +61,7 @@ tide_right_prompt_frame_enabled false
 tide_right_prompt_item_separator_diff_color ' '
 tide_right_prompt_item_separator_same_color ' '
 tide_right_prompt_item_separator_same_color_color 949494
-tide_right_prompt_items 'status' 'cmd_duration' 'context' 'jobs' 'virtual_env'
+tide_right_prompt_items 'status' 'cmd_duration' 'context' 'jobs' 'nvm' 'virtual_env'
 tide_right_prompt_pad_items false
 tide_right_prompt_prefix ' '
 tide_right_prompt_suffix ''
@@ -83,3 +83,5 @@ tide_virtual_env_bg_color normal
 tide_virtual_env_color 00AFAF
 tide_virtual_env_display_mode 'projectName'
 tide_virtual_env_icon ''
+tide_nvm_color 00AFAF
+tide_nvm_icon ''

--- a/tide_theme/configure/configs/pure.fish
+++ b/tide_theme/configure/configs/pure.fish
@@ -32,7 +32,7 @@ tide_left_prompt_frame_enabled false
 tide_left_prompt_item_separator_diff_color ' '
 tide_left_prompt_item_separator_same_color ' '
 tide_left_prompt_item_separator_same_color_color 949494
-tide_left_prompt_items 'pwd' 'git_prompt' 'cmd_duration' 'virtual_env' 'newline' 'prompt_char'
+tide_left_prompt_items 'pwd' 'git_prompt' 'cmd_duration' 'nvm' 'virtual_env' 'newline' 'prompt_char'
 tide_left_prompt_pad_items false
 tide_left_prompt_prefix ''
 tide_left_prompt_suffix ' '
@@ -83,3 +83,5 @@ tide_virtual_env_bg_color normal
 tide_virtual_env_color 00AFAF
 tide_virtual_env_display_mode 'projectName'
 tide_virtual_env_icon ''
+tide_nvm_color 00AFAF
+tide_nvm_icon ''

--- a/tide_theme/configure/configs/pure.fish
+++ b/tide_theme/configure/configs/pure.fish
@@ -36,6 +36,9 @@ tide_left_prompt_items 'pwd' 'git_prompt' 'cmd_duration' 'nvm' 'virtual_env' 'ne
 tide_left_prompt_pad_items false
 tide_left_prompt_prefix ''
 tide_left_prompt_suffix ' '
+tide_nvm_color 00AFAF
+tide_nvm_default_node
+tide_nvm_icon '⬢'
 tide_os_bg_color normal
 tide_os_color normal
 tide_os_use_nearest true
@@ -83,5 +86,3 @@ tide_virtual_env_bg_color normal
 tide_virtual_env_color 00AFAF
 tide_virtual_env_display_mode 'projectName'
 tide_virtual_env_icon ''
-tide_nvm_color 00AFAF
-tide_nvm_icon ''

--- a/tide_theme/configure/configs/rainbow.fish
+++ b/tide_theme/configure/configs/rainbow.fish
@@ -61,7 +61,7 @@ tide_right_prompt_frame_enabled true
 tide_right_prompt_item_separator_diff_color ''
 tide_right_prompt_item_separator_same_color ''
 tide_right_prompt_item_separator_same_color_color 949494
-tide_right_prompt_items 'status' 'cmd_duration' 'context' 'jobs' 'virtual_env'
+tide_right_prompt_items 'status' 'cmd_duration' 'context' 'jobs' 'nvm' 'virtual_env'
 tide_right_prompt_pad_items true
 tide_right_prompt_prefix ''
 tide_right_prompt_suffix ''
@@ -83,3 +83,5 @@ tide_virtual_env_bg_color 444444
 tide_virtual_env_color 00AFAF
 tide_virtual_env_display_mode 'projectName'
 tide_virtual_env_icon ''
+tide_nvm_color 00AFAF
+tide_nvm_icon ''

--- a/tide_theme/configure/configs/rainbow.fish
+++ b/tide_theme/configure/configs/rainbow.fish
@@ -36,6 +36,9 @@ tide_left_prompt_items 'pwd' 'git_prompt' 'newline'
 tide_left_prompt_pad_items true
 tide_left_prompt_prefix ''
 tide_left_prompt_suffix ''
+tide_nvm_color 00AFAF
+tide_nvm_default_node
+tide_nvm_icon '⬢'
 tide_os_bg_color CED7CF
 tide_os_color 080808
 tide_os_use_nearest true
@@ -83,5 +86,3 @@ tide_virtual_env_bg_color 444444
 tide_virtual_env_color 00AFAF
 tide_virtual_env_display_mode 'projectName'
 tide_virtual_env_icon ''
-tide_nvm_color 00AFAF
-tide_nvm_icon ''

--- a/tide_theme/configure/prompt_items/_fake_tide_item_nvm.fish
+++ b/tide_theme/configure/prompt_items/_fake_tide_item_nvm.fish
@@ -1,0 +1,2 @@
+function _fake_tide_item_nvm
+end

--- a/tools/_tide_actual_install.fish
+++ b/tools/_tide_actual_install.fish
@@ -75,6 +75,7 @@ function _set_immutables
     _set_immutable _tide_color_normal (set_color normal)
 
     _set_immutable VIRTUAL_ENV_DISABLE_PROMPT true
+    _set_immutable NVM_DIR $HOME/.nvm
 end
 
 function _set_immutable -a var_name


### PR DESCRIPTION
Display node version when using nvm.


#### Motivation and Context

People keep multiple node versions using nvm. This helps in better visibility of shell environment.

#### Screenshots (if appropriate)

#### How Has This Been Tested

Tested with local `nvm`.

- [x] I have tested using **MacOS**.
- [x] I have tested using **Linux**.

#### Checklist

- [ ] I have updated the documentation accordingly.
Documentation has moved to wiki. Will update once PR is accepted.

~- [ ] I have updated the tests accordingly.
Waiting for first review. Adding test cases not easy without running in a container.~ *Unnecessary for now*
