### PR TITLE
Explain variable modification for configuration

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -14,7 +14,7 @@ Variables in these sections will be denoted as `foo_bar` but will actually be `t
 
 You can take a look at the default configurations in `~/.config/fish/tide_theme/configure/configs` for inspiration.
 
-Do not customize these variables directly in `fish_variables`, use `set --universal` or `set --global` in your `config.fish` file.
+You can modify variables using `set --universal` from the command line or `set --global` in your `config.fish` file.
 
 ## Prompt Variables
 
@@ -59,11 +59,9 @@ Do not customize these variables directly in `fish_variables`, use `set --univer
 
 ## Items
 
-These can be added to `tide_left_prompt_items` or `tide_right_prompt_items`.
-You can modify these variables using `set --universal` or `set --global` from your `config.fish` file.
-For example, to add `context` on the far left of your left prompt:
+These can be added to `tide_left_prompt_items` or `tide_right_prompt_items`. For example, to add `context` to the far left of your left prompt:
 
-```fish
+```console
 set --universal tide_left_prompt_items context $tide_left_prompt_items
 ```
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -57,6 +57,8 @@ You can take a look at the default configurations in `~/.config/fish/tide_theme/
 
 ## Items
 
+These can be added to `tide_left_prompt_items` or `tide_right_prompt_items` in `~/.config/fish/fish_variables`.
+
 | Item                          | Description                       |
 | ----------------------------- | --------------------------------- |
 | [cmd_duration](#cmd_duration) | duration of the last run command  |

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -14,6 +14,8 @@ Variables in these sections will be denoted as `foo_bar` but will actually be `t
 
 You can take a look at the default configurations in `~/.config/fish/tide_theme/configure/configs` for inspiration.
 
+Do not customize these variables directly in `fish_variables`, use `set --universal` or `set --global` in your `config.fish` file.
+
 ## Prompt Variables
 
 | Variable                         | Description                           | Type    |
@@ -57,7 +59,13 @@ You can take a look at the default configurations in `~/.config/fish/tide_theme/
 
 ## Items
 
-These can be added to `tide_left_prompt_items` or `tide_right_prompt_items` in `~/.config/fish/fish_variables`.
+These can be added to `tide_left_prompt_items` or `tide_right_prompt_items`.
+You can modify these variables using `set --universal` or `set --global` from your `config.fish` file.
+For example, to add `context` on the far left of your left prompt:
+
+```fish
+set --universal tide_left_prompt_items context $tide_left_prompt_items
+```
 
 | Item                          | Description                       |
 | ----------------------------- | --------------------------------- |


### PR DESCRIPTION
Add a line to the documentation to clarify where one can add new items to the prompt manually.

#### Description

From the documentation it wasn't immediately clear to me where to find the configuration of the prompt and how to add new items. This PR adds a single line above the list of items to clarify where these can be added.

#### How Has This Been Tested

Documentation patch, no tests.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [x] I have updated the documentation accordingly.
