### PR TITLE
Use TMPDIR

### DIFF
--- a/functions/_tide_detect_os.fish
+++ b/functions/_tide_detect_os.fish
@@ -17,6 +17,7 @@ function _tide_detect_os
 end
 
 function _tide_detect_os_linux_cases -a file key
+    test ! -f $file && return 1
     set -l splitOsRelease (cat $file | string split '=')
     set -l value $splitOsRelease[(math (contains --index $key $splitOsRelease)+1)]
     set -l name (string trim --chars='"' $value | string lower)

--- a/functions/_tide_sub_test.fish
+++ b/functions/_tide_sub_test.fish
@@ -20,7 +20,7 @@ function _tide_sub_test
 
     if ! set -q TMPDIR
         set -g TMPDIR /tmp
-    endif
+    end
 
     set -lx TERM xterm # Necessary for testing purposes, ensures color codes are printed
 

--- a/functions/_tide_sub_test.fish
+++ b/functions/_tide_sub_test.fish
@@ -18,13 +18,17 @@ function _tide_sub_test
         return 1
     end
 
+    if ! set -q TMPDIR
+        set -g TMPDIR /tmp
+    endif
+
     set -lx TERM xterm # Necessary for testing purposes, ensures color codes are printed
 
     set -l testsDir "$_tide_dir/tests"
 
-    set -l pending '/tmp/tide_test'
-    set -l failed '/tmp/tide_test_failed'
-    set -l passed '/tmp/tide_test_passed'
+    set -l pending "$TMPDIR/tide_test"
+    set -l failed "$TMPDIR/tide_test_failed"
+    set -l passed "$TMPDIR/tide_test_passed"
 
     set -l returnStatement 0
 

--- a/tools/_tide_actual_install.fish
+++ b/tools/_tide_actual_install.fish
@@ -11,7 +11,11 @@ function _tide_actual_install
     printf '%s\n' 'Installing tide theme...'
 
     # -----------------Download Files-----------------
-    set -lx tempDir '/tmp/tide_theme'
+    if ! set -q TMPDIR
+        set -g TMPDIR /tmp
+    endif
+
+    set -lx tempDir "$TMPDIR/tide_theme"
     if test -e $tempDir
         rm -rf $tempDir
     end

--- a/tools/_tide_actual_install.fish
+++ b/tools/_tide_actual_install.fish
@@ -13,7 +13,7 @@ function _tide_actual_install
     # -----------------Download Files-----------------
     if ! set -q TMPDIR
         set -g TMPDIR /tmp
-    endif
+    end
 
     set -lx tempDir "$TMPDIR/tide_theme"
     if test -e $tempDir


### PR DESCRIPTION
This pull request replaces hard-coded references to `/tmp` with `$TMPDIR` to enable installation in contexts where `/tmp` is not
available, e.g. using Termux on Android.

#### Description

Hard-coded references to `/tmp` are replaced with `$TMPDIR`, and strings containing `/tmp` now use double quotes for proper
variable expansion. Before use, `TMPDIR`'s existence is tested and, if not found, set globally (script-local) to `/tmp`, for backwards-compatibility.

#### How Has This Been Tested

Because `$TMPDIR` is used during installation and certain paths are hardcoded, I tested the logic of my changes in the shell rather than testing the scripts themselves:

```fish
set -u TMPDIR
if ! set -q TMPDIR
    set -l TMPDIR /tmp
end
echo "$TMPDIR" # Nothing
if ! set -q TMPDIR
    set -g TMPDIR /tmp
end
echo "$TMPDIR" # "/tmp"
set -g TMPDIR /var/tmp
if ! set -q TMPDIR
    set -g TMPDIR /tmp
end
echo "$TMPDIR" # "/var/tmp"
```

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [x] I have updated the documentation accordingly. (I do not think anything needs to be updated?)
- [x] I have updated the tests accordingly. (There do not look to be any installation tests, so nothing to update?)
