### PR TITLE
Prevent error messages while detecting OS

### DIFF
--- a/functions/_tide_detect_os.fish
+++ b/functions/_tide_detect_os.fish
@@ -17,7 +17,10 @@ function _tide_detect_os
 end
 
 function _tide_detect_os_linux_cases -a file key
-    test ! -f $file && return 1
+    if not test -f $file
+        return 1
+    end
+
     set -l splitOsRelease (cat $file | string split '=')
     set -l value $splitOsRelease[(math (contains --index $key $splitOsRelease)+1)]
     set -l name (string trim --chars='"' $value | string lower)

--- a/functions/_tide_detect_os.fish
+++ b/functions/_tide_detect_os.fish
@@ -17,6 +17,7 @@ function _tide_detect_os
 end
 
 function _tide_detect_os_linux_cases -a file key
+    test ! -f $file && return 1
     set -l splitOsRelease (cat $file | string split '=')
     set -l value $splitOsRelease[(math (contains --index $key $splitOsRelease)+1)]
     set -l name (string trim --chars='"' $value | string lower)


### PR DESCRIPTION
Using tide on openSUSE Tumbleweed causes the following to be printed out when opening a new shell:

```
cat: /etc/lsb-release: No such file or directory
math: Expected at least 1 args, got 0
```

This pull request fixes this by short-circuiting `_tide_detect_os_linux_cases` and returning 1 if the given file does not exist.

#### Description

At the top of `_tide_detect_os_linux_cases`, a check was added to test if the given path is a file and, if not, `return 1`.

**Note:** I considered using `test -e` to allow for symbolic links, but decided against it because it also returns true for
directories, which would be invalid. AFAIK, `/etc/os-release` and `/etc/lsb-release` are not symlinks on any distros, if they exist, so using `-f` should be fine? `test -L` could also be used, but I don't think it checks if the target of the link is a file, and implementing a thorough check using `readlink` is only something the occurred to me while writing this pull request and seems unnecessary for the files being checked.

#### How Has This Been Tested

I tested the logic manually in the shell just to be sure, but it's a simple enough line of code that I think it can be verified as correct by looking at it.

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

I do not think there are any tests for this, since it occurs during installation. If I am wrong, I can go back and modify tests. Similarly, I do not think there is any documentation related to this.

- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
