### PR TITLE
use mktemp instead of explicitly named files

### DIFF
--- a/functions/_tide_sub_test.fish
+++ b/functions/_tide_sub_test.fish
@@ -22,9 +22,9 @@ function _tide_sub_test
 
     set -l testsDir "$_tide_dir/tests"
 
-    set -l pending '/tmp/tide_test'
-    set -l failed '/tmp/tide_test_failed'
-    set -l passed '/tmp/tide_test_passed'
+    set -l pending (mktemp)
+    set -l failed (mktemp)
+    set -l passed (mktemp)
 
     set -l returnStatement 0
 

--- a/functions/_tide_sub_test.fish
+++ b/functions/_tide_sub_test.fish
@@ -22,9 +22,9 @@ function _tide_sub_test
 
     set -l testsDir "$_tide_dir/tests"
 
-    set -l pending (mktemp)
-    set -l failed (mktemp)
-    set -l passed (mktemp)
+    set -l pending (mktemp -u)
+    set -l failed (mktemp -u)
+    set -l passed (mktemp -u)
 
     set -l returnStatement 0
 

--- a/tools/_tide_actual_install.fish
+++ b/tools/_tide_actual_install.fish
@@ -11,14 +11,11 @@ function _tide_actual_install
     printf '%s\n' 'Installing tide theme...'
 
     # -----------------Download Files-----------------
-    set -lx tempDir '/tmp/tide_theme'
-    if test -e $tempDir
-        rm -rf $tempDir
-    end
+    set -lx tempDir (mktemp -d)
 
     # Copy/clone repository into $tempDir
     if set -q _flag_local
-        cp -rf "$location" "$tempDir"
+        cp -r $location/* $tempDir
     else
         git clone --quiet --depth 1 --branch $location https://github.com/IlanCosman/tide.git $tempDir
     end

--- a/tools/_tide_actual_install.fish
+++ b/tools/_tide_actual_install.fish
@@ -11,11 +11,11 @@ function _tide_actual_install
     printf '%s\n' 'Installing tide theme...'
 
     # -----------------Download Files-----------------
-    set -lx tempDir (mktemp -d)
+    set -lx tempDir (mktemp -u)
 
     # Copy/clone repository into $tempDir
     if set -q _flag_local
-        cp -r $location/* $tempDir
+        cp -r $location $tempDir
     else
         git clone --quiet --depth 1 --branch $location https://github.com/IlanCosman/tide.git $tempDir
     end


### PR DESCRIPTION
Version 2 of pull request #39. This time, it uses mktemp and the variable name `tempDir` (as found in existing code). These changes are in the `_tide_sub_test` and `_tide_actual_install` functions.

#### Description

The code was copied and pasted between both sections because I was not sure where it would be a good idea to put a function. It first checks if the version of mktemp is the GNU one, because it added the `--tmpdir` flag and deprecated `-t`, which is the preferred method on BSD/macOS systems, then runs the correct invocation to get the path.

If creating the temporary directory fails, both functions will exit.

`tempDir` is created as a global variable in both instances and is unexported with `set -u` in `_tide_actual_install` to attempt to prevent issues for the user.

#### How Has This Been Tested

I tested the individual pieces of the code manually in my shell. Temporary directory creation works using the GNU version; BSD was untested but assumed to work since it was written based on the man page(s).

I ran the tests using the modified version of `_tide_sub_test` and there were no visible issues.

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

I do not think there is documentation to update.

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
