### PR TITLE
Erase _tide_* "private" functions

### DIFF
--- a/conf.d/_tide_init.fish
+++ b/conf.d/_tide_init.fish
@@ -53,7 +53,8 @@ function _tide_init_uninstall --on-event _tide_init_uninstall
     end
     set -e _tide_var_immutable_list
     set -e _tide_var_list
-    functions -e (functions --all | string match -- --entire --regex '^_tide_')
+
+    functions --erase (functions --all | string match --entire --regex '^_tide_')
 end
 
 function _set_immutable -a var_name

--- a/conf.d/_tide_init.fish
+++ b/conf.d/_tide_init.fish
@@ -53,6 +53,7 @@ function _tide_init_uninstall --on-event _tide_init_uninstall
     end
     set -e _tide_var_immutable_list
     set -e _tide_var_list
+    functions -e (functions --all | string match -- --entire --regex '^_tide_')
 end
 
 function _set_immutable -a var_name


### PR DESCRIPTION
#### Description

If we don't erase `_tide_` functions on uninstall, they remain in the global scope.  This is problematic for functions that register event handlers as they may fire even after Tide is uninstalled, e.g. [`_tide_quit`](https://github.com/IlanCosman/tide/blob/59ff037b74f293174a391759e4ab52cfb939bed5/functions/_tide_sub_configure.fish#L89-L94). See #42.

#### Motivation and Context

Prevent errors after Tide is uninstalled from your system. Closes #42.

#### How Has This Been Tested

- [x] I have tested using **MacOS**.

