### PR TITLE
Move fish_right_prompt to fish_right_prompt.fish

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -13,10 +13,3 @@ function fish_prompt --description 'Created by tide configure'
     _tide_right_prompt
     _tide_left_prompt
 end
-
-function fish_right_prompt
-    printf '%s' $_tide_fish_right_prompt_display
-    # Right prompt is always the last thing on the line 
-    # therefore reset colors for tab completion
-    set_color normal
-end

--- a/functions/fish_right_prompt.fish
+++ b/functions/fish_right_prompt.fish
@@ -1,0 +1,6 @@
+function fish_right_prompt
+    printf '%s' $_tide_fish_right_prompt_display
+    # Right prompt is always the last thing on the line 
+    # therefore reset colors for tab completion
+    set_color normal
+end


### PR DESCRIPTION
If we keep the `fish_right_prompt` function in `fish_prompt`, it stays defined in the session even if one uninstalls Tide.