### PR TITLE
Set color to normal at end of prompt char

### DIFF
--- a/functions/_tide_item_prompt_char.fish
+++ b/functions/_tide_item_prompt_char.fish
@@ -19,5 +19,4 @@ function _tide_item_prompt_char
                 printf '%s' $tide_prompt_char_vi_visual_icon' '
         end
     end
-    set_color normal
 end

--- a/functions/_tide_item_prompt_char.fish
+++ b/functions/_tide_item_prompt_char.fish
@@ -19,4 +19,5 @@ function _tide_item_prompt_char
                 printf '%s' $tide_prompt_char_vi_visual_icon' '
         end
     end
+    set_color normal
 end

--- a/functions/_tide_prompt.fish
+++ b/functions/_tide_prompt.fish
@@ -11,4 +11,5 @@ function _tide_prompt
 
     _tide_right_prompt
     _tide_left_prompt
+    set_color normal
 end


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Description

<!-- Describe your changes. -->

Set color to normal at end of prompt char

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
This will fix wrong coloring when pasting.

#### Screenshots (if appropriate)

Currently the color of commands is affected by the prompt char when pasting commands.

<img width="223" alt="Screenshot_20201230_213637" src="https://user-images.githubusercontent.com/12483662/103354751-5b9f4f00-4ae7-11eb-8007-c5468df3e036.png">

Fixes #64 