### PR TITLE
Fix errors displayed when using tide prompt with conda

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -27,7 +27,7 @@ function fish_prompt
 end
 
 function _tide_refresh_prompt --on-variable _tide_left_prompt_display_$fish_pid --on-variable _tide_right_prompt_display_$fish_pid
-    commandline --function force-repaint
+    commandline --function force-repaint 2>/dev/null
 end
 
 # Double underscores to avoid erasing this function on uninstall


### PR DESCRIPTION
This fixes a spam of warning messages which print out after every prompt, when using tide together with [conda](https://github.com/conda/conda)

This has been working on Linux and MacOS for me for the last month.

**Example warning messages printed out after every prompt:**
```
commandline: Can not set commandline in non-interactive mode

~/.config/fish/functions/fish_prompt.fish (line 30): 
    commandline --function force-repaint
    ^
in function '_tide_refresh_prompt' with arguments 'VARIABLE SET _tide_right_prompt_display_48151'
	called on line 1 of file ~/.config/fish/functions/_tide_right_prompt.fish
in event handler: handler for variable “_tide_right_prompt_display_48151”
	called on line 24 of file ~/.config/fish/functions/_tide_right_prompt.fish

(Type 'help commandline' for related documentation)
commandline: Can not set commandline in non-interactive mode
```


- [x] I have tested using **Linux**.
- [x] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
