### PR TITLE
Add ruby item

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -75,6 +75,7 @@ set --universal tide_left_prompt_items context $tide_left_prompt_items
 | [os](#os)                     | current operating system          |
 | [prompt_char](#prompt_char)   | prompt symbol; turns red on error |
 | [pwd](#pwd)                   | current directory                 |
+| [ruby](#ruby)                 | ruby version number               |
 | [rust](#rust)                 | rust version number               |
 | [status](#status)             | exit code of the last command     |
 | [time](#time)                 | current time                      |
@@ -164,6 +165,15 @@ set --universal tide_left_prompt_items context $tide_left_prompt_items
 | markers              | if a directory contains any of these files/directories, it will be anchored            | list    |
 | truncate_margin      | start truncating when pwd is this many columns from terminal edge                      | integer |
 | unwritable_icon      | symbol to display when the directory is not writable by the user                       | string  |
+
+## ruby
+
+| Variable        | Description                                             | Type    |
+| --------------- | ------------------------------------------------------- | ------- |
+| bg_color        | background color of ruby item                           | color   |
+| color           | color of ruby item                                      | color   |
+| icon            | icon to display next to the ruby version                | string  |
+| verbose_version | Cut off patch number from version. "3.0.0p0" vs "3.0.0" | boolean |
 
 ## rust
 

--- a/functions/_tide_item_ruby.fish
+++ b/functions/_tide_item_ruby.fish
@@ -1,0 +1,12 @@
+function _tide_item_ruby
+    if command --quiet ruby && test -e .ruby-version -o (count *.rb) -gt 0
+        set_color $tide_ruby_color
+
+        if test "$tide_ruby_verbose_version" = false
+            # Cut off -patch_version. "3.0.0p0" vs "3.0.0"
+            printf '%s' $tide_ruby_icon' ' (ruby --version | string split ' ' | string split 'p')[2]
+        else
+            printf '%s' $tide_ruby_icon' ' (ruby --version | string split ' ')[2]
+        end
+    end
+end

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -65,10 +65,10 @@ tide_right_prompt_items 'status' 'cmd_duration' 'context' 'jobs' 'nvm' 'virtual_
 tide_right_prompt_pad_items true
 tide_right_prompt_prefix ''
 tide_right_prompt_suffix ''
-tide_rust_bg_color 444444
-tide_rust_color 00AFAF
-tide_rust_icon ''
-tide_rust_verbose_version true
+tide_ruby_bg_color CC342D
+tide_ruby_color white
+tide_ruby_icon ''
+tide_ruby_verbose_version true
 tide_status_always_display false
 tide_status_failure_bg_color 444444
 tide_status_failure_color D70000

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -31,6 +31,8 @@ tide_pwd_color_dirs cyan
 tide_pwd_color_truncated_dirs magenta
 tide_right_prompt_frame_color brblack
 tide_right_prompt_item_separator_same_color_color brblack
+tide_ruby_bg_color black
+tide_ruby_color red
 tide_rust_bg_color black
 tide_rust_color cyan
 tide_status_failure_bg_color black

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -65,6 +65,10 @@ tide_right_prompt_items 'status' 'cmd_duration' 'context' 'jobs' 'nvm' 'virtual_
 tide_right_prompt_pad_items false
 tide_right_prompt_prefix ' '
 tide_right_prompt_suffix ''
+tide_ruby_bg_color normal
+tide_ruby_color CC342D
+tide_ruby_icon ''
+tide_ruby_verbose_version true
 tide_rust_bg_color normal
 tide_rust_color 00AFAF
 tide_rust_icon ''

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -31,6 +31,8 @@ tide_pwd_color_dirs cyan
 tide_pwd_color_truncated_dirs magenta
 tide_right_prompt_frame_color brblack
 tide_right_prompt_item_separator_same_color_color brblack
+tide_ruby_bg_color normal
+tide_ruby_color red
 tide_rust_bg_color normal
 tide_rust_color cyan
 tide_status_failure_bg_color normal

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -65,6 +65,10 @@ tide_right_prompt_items 'status' 'cmd_duration' 'context' 'jobs' 'nvm' 'virtual_
 tide_right_prompt_pad_items true
 tide_right_prompt_prefix ''
 tide_right_prompt_suffix ''
+tide_ruby_bg_color CC342D
+tide_ruby_color white
+tide_ruby_icon ''
+tide_ruby_verbose_version true
 tide_rust_bg_color FF8700
 tide_rust_color 2E3436
 tide_rust_icon ''

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -31,6 +31,8 @@ tide_pwd_color_dirs brwhite
 tide_pwd_color_truncated_dirs white
 tide_right_prompt_frame_color brblack
 tide_right_prompt_item_separator_same_color_color brblack
+tide_ruby_bg_color red
+tide_ruby_color black
 tide_rust_bg_color yellow
 tide_rust_color black
 tide_status_failure_bg_color red

--- a/tests/ruby.fish
+++ b/tests/ruby.fish
@@ -1,0 +1,25 @@
+# RUN: %fish %s
+
+function _ruby
+    _tide_decolor (_tide_item_ruby)
+end
+
+set -l rubyDir ~/rubyTest
+mkdir -p $rubyDir
+cd $rubyDir
+
+mock ruby --version "echo ruby 2.6.3p62"
+set -lx tide_ruby_verbose_version true
+set -lx tide_ruby_icon 
+
+touch file.rb
+_ruby # CHECK:  2.6.3p62
+rm file.rb
+
+_ruby # CHECK:
+
+touch .ruby-version
+set -lx tide_ruby_verbose_version false
+_ruby # CHECK:  2.6.3
+
+rm -r $rubyDir


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Description

This change adds the Ruby version item to the prompt.

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### Motivation and Context

As a Ruby developer, it's great to see what version of Ruby I'm currently using.

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/940/107849369-229f0d80-6dfb-11eb-9ac2-65d332ce0475.png)

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->

I have tested manually on my machine and added tests.
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [ ] I have tested using **Linux**.
- [x] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

Question: How would I go about disabling the Ruby icon when my prompt has icons disabled? I'd like to add that. I've set the Nerd Font glyph correctly, but I do not currently use any kind of Nerd Font in my terminal.