### PR TITLE
Add support for poetry and conda virtualenvs

### DIFF
--- a/functions/_tide_item_virtual_env.fish
+++ b/functions/_tide_item_virtual_env.fish
@@ -2,10 +2,24 @@ function _tide_item_virtual_env
     if set -l splitVirtualEnv (string split '/' "$VIRTUAL_ENV")
         set_color $tide_virtual_env_color
 
-        if test "$tide_virtual_env_display_mode" = 'venvName'
-            printf '%s' $tide_virtual_env_icon' ' $splitVirtualEnv[-1]
-        else # Default to projectName
-            printf '%s' $tide_virtual_env_icon' ' $splitVirtualEnv[-2]
+        # Detect if the virtualenv was spawned by poetry
+        # then _OLD_VIRTUAL_PATH is set and VIRTUAL_ENV has the form
+        # /home/<user>/.cache/pypoetry/virtualenvs/myproject-j_EvlIcP-py3.8
+        if test -n "$_OLD_VIRTUAL_PATH"; and test $splitVirtualEnv[-3] = 'pypoetry'
+            # This is needed when the project name has a dash in it, e.g. fish-shell
+            # Split by - and discard the last two parts
+            set -l splitPoetryVirtualEnv (string split '-' $splitVirtualEnv[-1])
+            set -l poetryVirtualEnvName (string join '-' $splitPoetryVirtualEnv[1..-3])
+            printf '%s' $tide_virtual_env_icon' ' $poetryVirtualEnvName
+        else
+            if test "$tide_virtual_env_display_mode" = 'venvName'
+                printf '%s' $tide_virtual_env_icon' ' $splitVirtualEnv[-1]
+            else # Default to projectName
+                printf '%s' $tide_virtual_env_icon' ' $splitVirtualEnv[-2]
+            end
         end
+    else if test -n "$CONDA_DEFAULT_ENV"
+        # conda uses CONDA_DEFAULT_ENV instead of VIRTUAL_ENV
+        printf '%s' $tide_virtual_env_icon' ' $CONDA_DEFAULT_ENV
     end
 end

--- a/tests/virtual_env.fish
+++ b/tests/virtual_env.fish
@@ -20,3 +20,14 @@ _virtual_env # CHECK:  .venv
 set -lx tide_virtual_env_icon
 set -lx tide_virtual_env_display_mode projectName
 _virtual_env # CHECK: python_project
+
+# Support for poetry virtualenvs
+set -lx VIRTUAL_ENV /home/user/.cache/pypoetry/virtualenvs/project-j_EVlIcP-py3.8
+_virtual_env # CHECK: project
+set -lx VIRTUAL_ENV /home/user/.cache/pypoetry/virtualenvs/some-project-j_EVlIcP-py3.8
+_virtual_env # CHECK: some-project
+
+# Support for conda virtualenvs
+set -lx VIRTUAL_ENV
+set -lx CONDA_DEFAULT_ENV base
+_virtual_env # CHECK: base

--- a/tests/virtual_env.fish
+++ b/tests/virtual_env.fish
@@ -22,6 +22,7 @@ set -lx tide_virtual_env_display_mode projectName
 _virtual_env # CHECK: python_project
 
 # Support for poetry virtualenvs
+set -lx _OLD_VIRTUAL_PATH /some /paths # set by poetry
 set -lx VIRTUAL_ENV /home/user/.cache/pypoetry/virtualenvs/project-j_EVlIcP-py3.8
 _virtual_env # CHECK: project
 set -lx VIRTUAL_ENV /home/user/.cache/pypoetry/virtualenvs/some-project-j_EVlIcP-py3.8


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

### Description

Adds support for conda envs and proper displaying of poetry virtualenvs.

### Describe your changes

Updated `_tide_item_virtual_env`.

If `VIRTUAL_ENV` is not set, it will be checked if `CONDA_DEFAULT_ENV` is set

If poetry is detected, we pick the last part of the virtualenv part as the name.
```
/home/user/.cache/pypoetry/virtualenvs/some-project-j_EVlIcP-py3.8
```

Within the last part, we split by `-` and throw away the last two elements.

### Why is this change required? What problem does it solve? 
Closes #97

### How Has This Been Tested
See `tests/virtual_env.fish`. For me, the tests I changed ran fine, but the rust test failed for some reason.

```
$ python3 ./littlecheck/littlecheck/littlecheck.py ./tests/**
Failure in ./tests/rust.fish:

  The CHECK on line 16 wants:
    \xe7a8 1.30.0-beta

  but there was no remaining output to match.

  Context:
     <= nothing to match CHECK '\xe7a8 1.30.0-beta' on line 16
     <= nothing to match CHECK '\xe7a8 1.30.0' on line 23

  when running command:
    fish ./tests/rust.fish
```

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
