### PR TITLE
Add option for shorter hostname

### DIFF
--- a/functions/_tide_item_context.fish
+++ b/functions/_tide_item_context.fish
@@ -1,12 +1,20 @@
 function _tide_item_context
+    set -l displayedHost $hostname
+
+    if test "$tide_short_hostname" = 'true'
+        # note: might break for IPs
+        # TODO: regex for IPv4/IPv6
+        set displayedHost (string join '.' (string split '.' $displayedHost)[1..-3])
+    end
+
     if set -q SSH_TTY
         set_color $tide_context_ssh_color
-        printf '%s' $USER'@'$hostname
+        printf '%s' $USER'@'$displayedHost
     else if test $USER = 'root'
         set_color $tide_context_root_color
-        printf '%s' $USER'@'$hostname
+        printf '%s' $USER'@'$displayedHost
     else if test "$tide_context_always_display" = 'true'
         set_color $tide_context_default_color
-        printf '%s' $USER'@'$hostname
+        printf '%s' $USER'@'$displayedHost
     end
 end


### PR DESCRIPTION
### Description

Host names can be rather long for some machines. For instance, if your machine has a [FQDN](https://en.wikipedia.org/wiki/Fully_qualified_domain_name) set, the `$hostname` variable evaluates to `mymachine.mydomain.tld`, which can take up a lot of space in the terminal.

This pull request proposes a configuration option `short_hostname`, which strips away the domain end of the hostname.  
So for an FQDN of `mymachine.mydomain.tld`, we only display `mymachine`.

### How Has This Been Tested

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

### Checklist

- [ ] IPs are handled correctly (is this needed?)
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
