### PR TITLE
Refresh only if session is interactive

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -5,13 +5,16 @@ set -g _tide_left_prompt_display_var _tide_left_prompt_display_$fish_pid
 
 set -gx _tide_fish_pid $fish_pid
 
-function fish_prompt
-    set -lx _tide_last_pipestatus $pipestatus
 
-    if not set -e _tide_repainting
-        set -lx _tide_jobs_number (jobs --pid | count)
 
-        fish --command "
+if status is-interactive
+    function fish_prompt
+        set -lx _tide_last_pipestatus $pipestatus
+
+        if not set -e _tide_repainting
+            set -lx _tide_jobs_number (jobs --pid | count)
+
+            fish --command "
         set CMD_DURATION $CMD_DURATION
         set COLUMNS $COLUMNS
         set fish_bind_mode $fish_bind_mode
@@ -21,26 +24,25 @@ function fish_prompt
         set -U _tide_left_prompt_display_$fish_pid (_tide_prompt)
         " >&- & # >&- closes stdout. See https://github.com/fish-shell/fish-shell/issues/7559
 
-        set -g _tide_last_pid (jobs --last --pid)
-        builtin disown $_tide_last_pid
+            set -g _tide_last_pid (jobs --last --pid)
+            builtin disown $_tide_last_pid
+        end
+
+        string unescape $$_tide_left_prompt_display_var
     end
 
-    string unescape $$_tide_left_prompt_display_var
-end
-
-if status is-interactive
     function _tide_refresh_prompt --on-variable _tide_left_prompt_display_$fish_pid --on-variable _tide_right_prompt_display_$fish_pid
         set -g _tide_repainting
         commandline --function force-repaint
     end
+
+    # Double underscores to avoid erasing this function on uninstall
+    function __tide_on_fish_exit --on-event fish_exit
+        set -e _tide_left_prompt_display_$fish_pid
+        set -e _tide_right_prompt_display_$fish_pid
+    end
 else
-    function _tide_refresh_prompt --on-variable _tide_left_prompt_display_$fish_pid --on-variable _tide_right_prompt_display_$fish_pid
+    function fish_prompt
         # do nothing when not interactive
     end
-end
-
-# Double underscores to avoid erasing this function on uninstall
-function __tide_on_fish_exit --on-event fish_exit
-    set -e _tide_left_prompt_display_$fish_pid
-    set -e _tide_right_prompt_display_$fish_pid
 end

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -29,8 +29,10 @@ function fish_prompt
 end
 
 function _tide_refresh_prompt --on-variable _tide_left_prompt_display_$fish_pid --on-variable _tide_right_prompt_display_$fish_pid
-    set -g _tide_repainting
-    commandline --function force-repaint
+    if status is-interactive
+        set -g _tide_repainting
+        commandline --function force-repaint
+    end
 end
 
 # Double underscores to avoid erasing this function on uninstall

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -15,14 +15,14 @@ if status is-interactive
             set -lx _tide_jobs_number (jobs --pid | count)
 
             fish --command "
-        set CMD_DURATION $CMD_DURATION
-        set COLUMNS $COLUMNS
-        set fish_bind_mode $fish_bind_mode
-        set fish_term24bit $fish_term24bit
+                set CMD_DURATION $CMD_DURATION
+                set COLUMNS $COLUMNS
+                set fish_bind_mode $fish_bind_mode
+                set fish_term24bit $fish_term24bit
 
-        command kill $_tide_last_pid 2>/dev/null
-        set -U _tide_left_prompt_display_$fish_pid (_tide_prompt)
-        " >&- & # >&- closes stdout. See https://github.com/fish-shell/fish-shell/issues/7559
+                command kill $_tide_last_pid 2>/dev/null
+                set -U _tide_left_prompt_display_$fish_pid (_tide_prompt)
+            " >&- & # >&- closes stdout. See https://github.com/fish-shell/fish-shell/issues/7559
 
             set -g _tide_last_pid (jobs --last --pid)
             builtin disown $_tide_last_pid

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -28,10 +28,14 @@ function fish_prompt
     string unescape $$_tide_left_prompt_display_var
 end
 
-function _tide_refresh_prompt --on-variable _tide_left_prompt_display_$fish_pid --on-variable _tide_right_prompt_display_$fish_pid
-    if status is-interactive
+if status is-interactive
+    function _tide_refresh_prompt --on-variable _tide_left_prompt_display_$fish_pid --on-variable _tide_right_prompt_display_$fish_pid
         set -g _tide_repainting
         commandline --function force-repaint
+    end
+else
+    function _tide_refresh_prompt --on-variable _tide_left_prompt_display_$fish_pid --on-variable _tide_right_prompt_display_$fish_pid
+        # do nothing when not interactive
     end
 end
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Description

After installing [miniconda](https://docs.conda.io/en/latest/miniconda.html) on my machine and initializing the shell using `conda init fish`, tide throws errors with every command.

```
╭─ ~/devel                                                                                                                                                            ✔  13:07:21 
╰─commandline: Can not set commandline in non-interactive mode                                                                                                                (py38) 

~/.config/fish/functions/fish_prompt.fish (line 33): 
    commandline --function force-repaint
    ^
in function '_tide_refresh_prompt' with arguments 'VARIABLE SET _tide_right_prompt_display_4029952'
        called on line 1 of file ~/.config/fish/functions/_tide_right_prompt.fish
in event handler: handler for variable “_tide_right_prompt_display_4029952”
        called on line 27 of file ~/.config/fish/functions/_tide_right_prompt.fish

(Type 'help commandline' for related documentation)
commandline: Can not set commandline in non-interactive mode

~/.config/fish/functions/fish_prompt.fish (line 33): 
    commandline --function force-repaint
    ^
in function '_tide_refresh_prompt' with arguments 'VARIABLE ERASE _tide_right_prompt_display_4029952'
        called on line 1 of file ~/.config/fish/functions/fish_prompt.fish
in event handler: handler for variable “_tide_right_prompt_display_4029952”
        called on line 39 of file ~/.config/fish/functions/fish_prompt.fish

(Type 'help commandline' for related documentation)
```

To fix this, I simply added a check to see whether we're currently interactive or not using [`status is-interactive`](https://fishshell.com/docs/current/cmds/status.html).

Related issue: [fish-shell#5394](https://github.com/fish-shell/fish-shell/issues/5394)

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
