### PR TITLE
Check for negative value when printing prompt connection

### DIFF
--- a/functions/_tide_prompt.fish
+++ b/functions/_tide_prompt.fish
@@ -23,14 +23,9 @@ function _tide_prompt
         printf '%s' $leftPrompt[1]
 
         set_color $tide_prompt_connection_color
-        set -l decoloredTextLength (_tide_decolor "$leftPrompt[1]""$rightPrompt[1]" | string length)
         test -n "$tide_prompt_connection_icon" || set -l tide_prompt_connection_icon ' '
-
-        set -l totalLength (math $COLUMNS - $decoloredTextLength)
-        if test $totalLength -lt 0
-            set totalLength 0
-        end
-        string repeat --no-newline --max $totalLength $tide_prompt_connection_icon
+        set -l lengthToMove (math $COLUMNS - (_tide_decolor "$leftPrompt[1]""$rightPrompt[1]" | string length))
+        test $lengthToMove -gt 0 && string repeat --no-newline --max $lengthToMove $tide_prompt_connection_icon
 
         printf '%s\n' $rightPrompt[1]
     end

--- a/functions/_tide_prompt.fish
+++ b/functions/_tide_prompt.fish
@@ -25,7 +25,12 @@ function _tide_prompt
         set_color $tide_prompt_connection_color
         set -l decoloredTextLength (_tide_decolor "$leftPrompt[1]""$rightPrompt[1]" | string length)
         test -n "$tide_prompt_connection_icon" || set -l tide_prompt_connection_icon ' '
-        string repeat --no-newline --max (math $COLUMNS - $decoloredTextLength) $tide_prompt_connection_icon
+
+        set -l totalLength (math $COLUMNS - $decoloredTextLength)
+        if test $totalLength -lt 0
+            set totalLength 0
+        end
+        string repeat --no-newline --max $totalLength $tide_prompt_connection_icon
 
         printf '%s\n' $rightPrompt[1]
     end


### PR DESCRIPTION
#### Description

applies to issue #120 

Check for a negative value before printing prompt connection to avoid issues with `string repeat`.

#### Motivation and Context

Closes #120 

#### Screenshots (if appropriate)

#### How Has This Been Tested

- [x] I have tested using **Linux**.
- [x] I have tested using **MacOS**.

This looks like it fixes the issue when I add it on both Linux and MacOS.

#### Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
