### PR TITLE
Add default item for Elixir projects

### DIFF
--- a/functions/_tide_item_elixir.fish
+++ b/functions/_tide_item_elixir.fish
@@ -1,0 +1,10 @@
+function _tide_item_elixir
+    mix deps >/dev/null 2>/dev/null
+
+    if test $status = 0
+        set -l elixirVersion (elixir -v | sed -n 's/Elixir //p;s/compiled with Erlang\///p')
+
+        set_color $tide_elixir_color
+        printf '%s' $tide_elixir_icon ' ' $elixirVersion
+    end
+end

--- a/functions/_tide_item_elixir.fish
+++ b/functions/_tide_item_elixir.fish
@@ -1,6 +1,6 @@
 function _tide_item_elixir
     if test -e mix.exs
-        set -l elixirVersion (elixir -v | sed -nr 's/Elixir //;s/compiled with Erlang\///p')
+        set -l elixirVersion (elixir -v | sed -n 's/Elixir //;s/compiled with Erlang\///p')
 
         set_color $tide_elixir_color
         printf '%s' $tide_elixir_icon ' ' $elixirVersion

--- a/functions/_tide_item_elixir.fish
+++ b/functions/_tide_item_elixir.fish
@@ -1,8 +1,6 @@
 function _tide_item_elixir
-    mix deps >/dev/null 2>/dev/null
-
-    if test $status = 0
-        set -l elixirVersion (elixir -v | sed -n 's/Elixir //p;s/compiled with Erlang\///p')
+    if test -e mix.exs
+        set -l elixirVersion (elixir -v | sed -nr 's/Elixir //;s/compiled with Erlang\///p')
 
         set_color $tide_elixir_color
         printf '%s' $tide_elixir_icon ' ' $elixirVersion

--- a/functions/_tide_item_elixir.fish
+++ b/functions/_tide_item_elixir.fish
@@ -1,6 +1,6 @@
 function _tide_item_elixir
     if test -e mix.exs
-        set -l elixirVersion (elixir -v | sed -n 's/Elixir //;s/compiled with Erlang\///p')
+        set -l elixirVersion (elixir -v | string replace -r 'Elixir ([0-9]+\.[0-9]+\.[0-9]+) \(compiled with Erlang\/(OTP [0-9]+)\)' '$1 \($2\)' | tail -1)
 
         set_color $tide_elixir_color
         printf '%s' $tide_elixir_icon ' ' $elixirVersion

--- a/functions/_tide_remove_unusable_items.fish
+++ b/functions/_tide_remove_unusable_items.fish
@@ -1,6 +1,6 @@
 function _tide_remove_unusable_items
     # Remove tool-specific items for tools the machine doesn't have installed
-    for item in chruby git nvm php rust virtual_env
+    for item in chruby git nvm php rust virtual_env elixir
         set -l cliName $item
         switch $item
             case virtual_env

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -8,6 +8,8 @@ tide_context_bg_color 444444
 tide_context_default_color D7AF87
 tide_context_root_color $_tide_color_gold
 tide_context_ssh_color D7AF87
+tide_elixir_icon 
+tide_elixir_color 9370DB
 tide_git_bg_color 444444
 tide_git_branch_color $_tide_color_green
 tide_git_conflicted_color FF0000

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -4,6 +4,7 @@ tide_context_bg_color black
 tide_context_default_color yellow
 tide_context_root_color bryellow
 tide_context_ssh_color yellow
+tide_elixir_color purple
 tide_git_bg_color black
 tide_git_branch_color brgreen
 tide_git_conflicted_color brred

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -8,6 +8,8 @@ tide_context_bg_color normal
 tide_context_default_color D7AF87
 tide_context_root_color $_tide_color_gold
 tide_context_ssh_color D7AF87
+tide_elixir_icon 
+tide_elixir_color 9370DB
 tide_git_bg_color normal
 tide_git_branch_color $_tide_color_green
 tide_git_conflicted_color FF0000

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -4,6 +4,7 @@ tide_context_bg_color normal
 tide_context_default_color yellow
 tide_context_root_color bryellow
 tide_context_ssh_color yellow
+tide_elixir_color purple
 tide_git_bg_color normal
 tide_git_branch_color brgreen
 tide_git_conflicted_color brred

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -8,6 +8,8 @@ tide_context_bg_color 444444
 tide_context_default_color D7AF87
 tide_context_root_color $_tide_color_gold
 tide_context_ssh_color D7AF87
+tide_elixir_icon 
+tide_elixir_color 9370DB
 tide_git_bg_color 4E9A06
 tide_git_branch_color 000000
 tide_git_conflicted_color 000000

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -4,6 +4,7 @@ tide_context_bg_color brblack
 tide_context_default_color yellow
 tide_context_root_color yellow
 tide_context_ssh_color yellow
+tide_elixir_color purple
 tide_git_bg_color green
 tide_git_branch_color black
 tide_git_conflicted_color black

--- a/tests/_tide_item_elixir.test.fish
+++ b/tests/_tide_item_elixir.test.fish
@@ -1,0 +1,19 @@
+# RUN: %fish %s
+
+function _elixir
+    _tide_decolor (_tide_item_elixir)
+end
+
+set -l elixirDir ~/elixirDir
+mkdir -p $elixirDir
+cd $elixirDir
+
+mock elixir -v "echo 'Elixir 1.10.4 (compiled with Erlang/OTP 23)'"
+set -lx tide_elixir_icon 
+
+_elixir # CHECK: 
+
+touch mix.exs
+_elixir # CHECK:  1.10.4 (OTP 23)
+
+rm -r $elixirDir


### PR DESCRIPTION
#### Description

Add` an default item to the project when navigating Elixir project directories.

#### Motivation and Context

I don´t think there´s a proper problem that this solves, but it´s a nice convenience for the Elixir developers and it broadens the amount of languages with items out of the box.

The method I used to identify an Elixir project is to check the presence of a `mix.exs` file in the directory.

#### Screenshots (if appropriate)
![2021-04-19-193111_957x44_scrot](https://user-images.githubusercontent.com/487047/115285973-735a1c00-a146-11eb-8af9-e1898e87b8b3.png)

#### How Has This Been Tested

A simple way to test is navigating through multiple projects with different Elixir and OTP versions.

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
