### PR TITLE
fix: commandline: Can not set commandline in non-interactive mode

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -9,8 +9,10 @@ set -g _tide_left_prompt_display_var _tide_left_prompt_display_$fish_pid
 set -gx _tide_right_prompt_display_var _tide_right_prompt_display_$fish_pid
 
 function _tide_refresh_prompt --on-variable $_tide_left_prompt_display_var --on-variable $_tide_right_prompt_display_var
-    set -g _tide_self_repainting # prevents us from creating a second background job
-    commandline --function repaint
+    if status is-interactive
+        set -g _tide_self_repainting # prevents us from creating a second background job
+        commandline --function repaint
+    end
 end
 
 function fish_prompt


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Description

I don't use the most recent version since my PopOS only has version 3.1.2 of fish but the problem might also be in the current master.
It happend when I added the conda hook to fish, I got the error message:

```
commandline: Can not set commandline in non-interactive mode

~/.config/fish/functions/fish_prompt.fish (line 33):
    commandline --function force-repaint
```

The error message is straight forward and there is an easy fix by wrapping the code block into an if clause.
I did this to the current master. Would be nice if this could be tested if it's still necessary. 
Cheers :)