### PR TITLE
Handle pipenv names

### DIFF
--- a/functions/_tide_item_virtual_env.fish
+++ b/functions/_tide_item_virtual_env.fish
@@ -1,13 +1,20 @@
 function _tide_item_virtual_env
     if set -l splitVirtualEnv (string split '/' "$VIRTUAL_ENV")
         set_color $tide_virtual_env_color
-        set -l directoryName (string split '/' (pwd))[-1]
-        string match -qe $directoryName- $splitVirtualEnv[-1]; set pipenvStyle $status
+        set -l pathSplit (string split '/' (pwd))
+        # Does one of the path segments match the venvRoot implied by assuming
+        # the virtualenv uses pipenv naming style?
+        for pathSegment in $pathSplit[-1..1]
+            if string match -qe "$pathSegment"- $splitVirtualEnv[-1]
+                set venvRoot (string split -r -m1 '-' $splitVirtualEnv[-1])[1]
+                break
+            end
+        end
         # Avoid printing a generic name
         if contains -- $splitVirtualEnv[-1] virtualenv venv .venv env
             printf '%s' $tide_virtual_env_icon' ' $splitVirtualEnv[-2]
-        else if test $pipenvStyle -eq 0
-            printf '%s' $tide_virtual_env_icon' ' $directoryName
+        else if test (count $venvRoot) -eq 1
+            printf '%s' $tide_virtual_env_icon' ' $venvRoot
         else
             printf '%s' $tide_virtual_env_icon' ' $splitVirtualEnv[-1]
         end

--- a/functions/_tide_item_virtual_env.fish
+++ b/functions/_tide_item_virtual_env.fish
@@ -1,20 +1,11 @@
 function _tide_item_virtual_env
     if set -l splitVirtualEnv (string split '/' "$VIRTUAL_ENV")
         set_color $tide_virtual_env_color
-        set -l pathSplit (string split '/' (pwd))
-        # Does one of the path segments match the venvRoot implied by assuming
-        # the virtualenv uses pipenv naming style?
-        for pathSegment in $pathSplit[-1..1]
-            if string match -qe "$pathSegment"- $splitVirtualEnv[-1]
-                set venvRoot (string split -r -m1 '-' $splitVirtualEnv[-1])[1]
-                break
-            end
-        end
         # Avoid printing a generic name
         if contains -- $splitVirtualEnv[-1] virtualenv venv .venv env
             printf '%s' $tide_virtual_env_icon' ' $splitVirtualEnv[-2]
-        else if test (count $venvRoot) -eq 1
-            printf '%s' $tide_virtual_env_icon' ' $venvRoot
+        else if string match -qe "$HOME/.local/share/virtualenvs/" $VIRTUAL_ENV
+            printf '%s' $tide_virtual_env_icon' ' (string split -r -m1 '-' $splitVirtualEnv[-1])[1]
         else
             printf '%s' $tide_virtual_env_icon' ' $splitVirtualEnv[-1]
         end

--- a/functions/_tide_item_virtual_env.fish
+++ b/functions/_tide_item_virtual_env.fish
@@ -1,9 +1,13 @@
 function _tide_item_virtual_env
     if set -l splitVirtualEnv (string split '/' "$VIRTUAL_ENV")
         set_color $tide_virtual_env_color
+        set -l directoryName (string split '/' (pwd))[-1]
+        string match -qe $directoryName- $splitVirtualEnv[-1]; set pipenvStyle $status
         # Avoid printing a generic name
         if contains -- $splitVirtualEnv[-1] virtualenv venv .venv env
             printf '%s' $tide_virtual_env_icon' ' $splitVirtualEnv[-2]
+        else if test $pipenvStyle -eq 0
+            printf '%s' $tide_virtual_env_icon' ' $directoryName
         else
             printf '%s' $tide_virtual_env_icon' ' $splitVirtualEnv[-1]
         end


### PR DESCRIPTION
Feat: Handle Pipenv Virtual Environment Names

This gets current directory name and compares with pipenv's
naming pattern. If it matches the output is changed to the
directory name instead or the virtual environment name.

#### Motivation and Context

Pipenv automatically generates and controls virtual environment names.
They take the form VenvRoot-######### where ######### represents a hash relating to the virtual environment.
This is unsightly and unnecessary - especially where horizontal space is at a premium.
I have reworked it so it just shows the name of the Virtual environment root directory.
I was also considering just making it show 'pipenv' but considering the comment in the existing code about not displaying generics I decided to go with the root directory name.

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.<!-- Provide a general summary of your changes in the Title above. -->