### PR TITLE
Add tide prompt item GO similiar to RUST support

### DIFF
--- a/functions/_tide_item_go.fish
+++ b/functions/_tide_item_go.fish
@@ -1,6 +1,6 @@
 function _tide_item_go
     if test -e go.mod
         set_color $tide_go_color
-        printf '%s' $tide_go_icon' ' (go version | string split ' ' | string trim --chars go)[3]
+        printf '%s' $tide_go_icon' ' (go version | string split ' ')[3]
     end
 end

--- a/functions/_tide_item_go.fish
+++ b/functions/_tide_item_go.fish
@@ -1,0 +1,6 @@
+function _tide_item_go
+    if test -e go.mod
+        set_color $tide_go_color
+        printf '%s' $tide_go_icon' ' (go version | string split ' ' | string trim --chars go)[3]
+    end
+end

--- a/functions/_tide_remove_unusable_items.fish
+++ b/functions/_tide_remove_unusable_items.fish
@@ -1,6 +1,6 @@
 function _tide_remove_unusable_items
     # Remove tool-specific items for tools the machine doesn't have installed
-    for item in chruby git nvm php rust virtual_env
+    for item in chruby git go nvm php rust virtual_env
         set -l cliName $item
         switch $item
             case virtual_env

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -75,7 +75,7 @@ tide_rust_color 00AFAF
 tide_rust_icon ''
 tide_go_bg_color 444444
 tide_go_color 00EFEF
-tide_go_icon ''
+tide_go_icon 'ﳑ'
 tide_status_failure_bg_color 444444
 tide_status_failure_color D70000
 tide_status_failure_icon '✘'

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -63,7 +63,7 @@ tide_right_prompt_frame_enabled true
 tide_right_prompt_item_separator_diff_color ''
 tide_right_prompt_item_separator_same_color ''
 tide_right_prompt_item_separator_same_color_color 949494
-tide_right_prompt_items status cmd_duration context jobs nvm virtual_env rust php vi_mode chruby
+tide_right_prompt_items status cmd_duration context jobs nvm virtual_env rust go php vi_mode chruby
 tide_right_prompt_pad_items true
 tide_right_prompt_prefix ''
 tide_right_prompt_suffix ''
@@ -73,6 +73,9 @@ tide_chruby_icon ''
 tide_rust_bg_color 444444
 tide_rust_color 00AFAF
 tide_rust_icon ''
+tide_go_bg_color 444444
+tide_go_color 00EFEF
+tide_go_icon ''
 tide_status_failure_bg_color 444444
 tide_status_failure_color D70000
 tide_status_failure_icon '✘'

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -37,6 +37,8 @@ tide_chruby_bg_color black
 tide_chruby_color red
 tide_rust_bg_color black
 tide_rust_color cyan
+tide_go_bg_color black
+tide_go_color cyan
 tide_status_failure_bg_color black
 tide_status_failure_color red
 tide_status_success_bg_color black

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -75,7 +75,7 @@ tide_rust_color 00AFAF
 tide_rust_icon ''
 tide_go_bg_color normal
 tide_go_color 00EFEF
-tide_go_icon ''
+tide_go_icon 'ﳑ'
 tide_status_failure_bg_color normal
 tide_status_failure_color D70000
 tide_status_failure_icon '✘'

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -63,7 +63,7 @@ tide_right_prompt_frame_enabled false
 tide_right_prompt_item_separator_diff_color ' '
 tide_right_prompt_item_separator_same_color ' '
 tide_right_prompt_item_separator_same_color_color 949494
-tide_right_prompt_items status cmd_duration context jobs nvm virtual_env rust php chruby
+tide_right_prompt_items status cmd_duration context jobs nvm virtual_env rust go php chruby
 tide_right_prompt_pad_items false
 tide_right_prompt_prefix ' '
 tide_right_prompt_suffix ''
@@ -73,6 +73,9 @@ tide_chruby_icon ''
 tide_rust_bg_color normal
 tide_rust_color 00AFAF
 tide_rust_icon ''
+tide_go_bg_color normal
+tide_go_color 00EFEF
+tide_go_icon ''
 tide_status_failure_bg_color normal
 tide_status_failure_color D70000
 tide_status_failure_icon '✘'

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -37,6 +37,8 @@ tide_chruby_bg_color normal
 tide_chruby_color red
 tide_rust_bg_color normal
 tide_rust_color cyan
+tide_go_bg_color normal
+tide_go_color cyan
 tide_status_failure_bg_color normal
 tide_status_failure_color red
 tide_status_success_bg_color normal

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -63,7 +63,7 @@ tide_right_prompt_frame_enabled true
 tide_right_prompt_item_separator_diff_color ''
 tide_right_prompt_item_separator_same_color ''
 tide_right_prompt_item_separator_same_color_color 949494
-tide_right_prompt_items status cmd_duration context jobs nvm virtual_env rust php vi_mode chruby
+tide_right_prompt_items status cmd_duration context jobs nvm virtual_env rust go php vi_mode chruby
 tide_right_prompt_pad_items true
 tide_right_prompt_prefix ''
 tide_right_prompt_suffix ''
@@ -73,6 +73,9 @@ tide_chruby_icon ''
 tide_rust_bg_color FF8700
 tide_rust_color 2E3436
 tide_rust_icon ''
+tide_go_bg_color FF8700
+tide_go_color 2E3436
+tide_go_icon ''
 tide_status_failure_bg_color CC0000
 tide_status_failure_color FFFF00
 tide_status_failure_icon '✘'

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -75,7 +75,7 @@ tide_rust_color 2E3436
 tide_rust_icon ''
 tide_go_bg_color FF8700
 tide_go_color 2E3436
-tide_go_icon ''
+tide_go_icon 'ﳑ'
 tide_status_failure_bg_color CC0000
 tide_status_failure_color FFFF00
 tide_status_failure_icon '✘'

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -37,6 +37,8 @@ tide_chruby_bg_color red
 tide_chruby_color black
 tide_rust_bg_color yellow
 tide_rust_color black
+tide_go_bg_color yellow
+tide_go_color black
 tide_status_failure_bg_color red
 tide_status_failure_color bryellow
 tide_status_success_bg_color black

--- a/tests/_tide_item_go.test.fish
+++ b/tests/_tide_item_go.test.fish
@@ -1,0 +1,19 @@
+# RUN: %fish %s
+
+function _go
+    _tide_decolor (_tide_item_go)
+end
+
+set -l goDir ~/goTest
+mkdir -p $goDir
+cd $goDir
+
+mock go version "echo go version go1.16.5 linux/amd64"
+set -lx tide_go_icon 
+
+_go # CHECK:
+
+touch go.mod
+_go # CHECK:  1.16.5
+
+rm -r $goDir

--- a/tests/_tide_item_go.test.fish
+++ b/tests/_tide_item_go.test.fish
@@ -9,11 +9,10 @@ mkdir -p $goDir
 cd $goDir
 
 mock go version "echo go version go1.16.5 linux/amd64"
-set -lx tide_go_icon 
+set -lx tide_go_icon ﳑ
 
 _go # CHECK:
 
 touch go.mod
-_go # CHECK:  1.16.5
-
+_go # CHECK: ﳑ go1.16.5
 rm -r $goDir


### PR DESCRIPTION
#### Description

Added prompt item for GO indicating go version number and small gopher icon

#### How Has This Been Tested

- [ X ] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

- [ ] I have updated the documentation accordingly.
- [ X ] I have updated the tests accordingly.
