### PR TITLE
isolate tests and add Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/littlecheck

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+SHELL := /usr/bin/env fish
+
+.PHONY: help
+help: ## Show this help
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z -]+:.*?## / {printf "\033[36m%-10s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
+
+littlecheck:
+	@echo "Downloading littlecheck.py..."
+	@curl -fsSL https://raw.githubusercontent.com/ridiculousfish/littlecheck/master/littlecheck/littlecheck.py -o littlecheck
+	@chmod +x littlecheck
+
+.PHONY: fmt
+fmt: ## Format codebase
+	@fish_indent -w **/*.fish
+
+.PHONY: lint
+lint: ## Lint codebase
+	@echo **/*.fish | xargs -n1 fish --no-execute
+
+.PHONY: test
+test: littlecheck ## Run tests
+	@type -q fisher || begin; curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher; end
+	@type -q mock || fisher install IlanCosman/clownfish
+	@fisher install . >/dev/null
+	@fish tests/test_setup.fish
+	@./littlecheck --progress tests/*.test.fish

--- a/tests/_tide_item_git.test.fish
+++ b/tests/_tide_item_git.test.fish
@@ -9,8 +9,7 @@ function _git_item
 end
 
 # Create directory
-set -l dir ~/gitItemTest
-rm -rf $dir
+set -l dir (mktemp -d)
 mkdir -p $dir/{normal-repo, bare-repo}
 
 # Not in git repo
@@ -62,3 +61,5 @@ cd $dir/bare-repo
 _git init --bare
 _git branch -m main
 _git_item # CHECK: main
+
+rm -r $dir

--- a/tests/_tide_item_go.test.fish
+++ b/tests/_tide_item_go.test.fish
@@ -4,8 +4,7 @@ function _go
     _tide_decolor (_tide_item_go)
 end
 
-set -l goDir ~/goTest
-mkdir -p $goDir
+set -l goDir (mktemp -d)
 cd $goDir
 
 mock go version "echo go version go1.16.5 linux/amd64"

--- a/tests/_tide_item_php.test.fish
+++ b/tests/_tide_item_php.test.fish
@@ -4,8 +4,7 @@ function _php
     _tide_decolor (_tide_item_php)
 end
 
-set -l phpDir ~/phpTest
-mkdir -p $phpDir
+set -l phpDir (mktemp -d)
 cd $phpDir
 
 mock php --version "echo \

--- a/tests/_tide_item_rustc.test.fish
+++ b/tests/_tide_item_rustc.test.fish
@@ -4,8 +4,7 @@ function _rustc
     _tide_decolor (_tide_item_rustc)
 end
 
-set -l rustcDir ~/rustcTest
-mkdir -p $rustcDir
+set -l rustcDir (mktemp -d)
 cd $rustcDir
 
 mock rustc --version "echo rustc 1.30.0"


### PR DESCRIPTION
#### Description

I noticed the tests currently write to the user's `$HOME`, so I made some tweaks to instead use a temp directory and not require `sudo`.

Also, I wrote a Makefile for my own convenience and figured I'd share. No worries if you're not interested.

```console
$ make
fmt        Format codebase
help       Show this help
lint       Lint codebase
test       Run tests

$ make test
Downloading littlecheck.py...
Testing file tests/_tide_item_chruby.test.fish ... ok (52.0 ms)
...
```

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [ ] I have tested using **Linux**.
- [x] I have tested using **MacOS**.

#### Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
