### PR TITLE
Use single underscore for `__tide_on_fish_exit`

### DIFF
--- a/conf.d/_tide_init.fish
+++ b/conf.d/_tide_init.fish
@@ -17,6 +17,6 @@ function _tide_init_install --on-event _tide_init_install
 end
 
 function _tide_init_uninstall --on-event _tide_init_uninstall
-    set -e $_tide_var_list _tide_var_list
+    set -e $_tide_var_list _tide_var_list $_tide_left_prompt_display_var $_tide_right_prompt_display_var
     functions --erase (functions --all | string match --entire --regex '^_tide_')
 end

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -27,7 +27,6 @@ function fish_prompt
     string unescape $$_tide_left_prompt_display_var
 end
 
-# Double underscores to avoid erasing this function on uninstall
-function __tide_on_fish_exit --on-event fish_exit
+function _tide_on_fish_exit --on-event fish_exit
     set -e $_tide_left_prompt_display_var $_tide_right_prompt_display_var
 end


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Description

Use single underscore for `__tide_on_fish_exit`, by replicating its functionality directly in `_tide_init_uninstall`, which is also more suitable IMO.

<!-- Describe your changes. -->

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Recently I've been thinking that most Fish plugins agree on using a single underscore for their "private" functions, while Fish exclusively uses two (except for `_validate_int`, which is being tackled with fish-shell/fish-shell#8168). Tide also follows this convention except for `__tide_on_fish_exit` due to technical reason, but I just realized this can solved the other way.

#### Screenshots (if appropriate)

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [ ] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
