### PR TITLE
configure: read single character

### DIFF
--- a/functions/_tide_sub_configure.fish
+++ b/functions/_tide_sub_configure.fish
@@ -58,7 +58,7 @@ function _tide_menu
 
     while true
         set_color -o
-        read --prompt-str "Choice [$list_with_slashes/r/q] " input
+        read --nchars 1 --prompt-str "Choice [$list_with_slashes/r/q] " input
         set_color normal
 
         switch $input


### PR DESCRIPTION
#### Description

This is very nitpicky, so feel free to close 😂 
<!-- Describe your changes. -->

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### Motivation and Context

Makes `tide configure` faster to go through (no need to hit enter), and matches `p10k configure`.

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [x] I have tested using **Linux**.
- [x] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
