### PR TITLE
Make Git icons configurable

### DIFF
--- a/functions/_tide_item_git.fish
+++ b/functions/_tide_item_git.fish
@@ -62,10 +62,10 @@ function _tide_item_git
 
     _tide_print_item git $_tide_location_color $tide_git_icon' ' (set_color white; printf %s $location
         set_color $tide_git_color_operation; printf %s ' '$tide_git_operation ' '$tide_git_step/$tide_git_total_steps
-        set_color $tide_git_color_upstream; printf %s ' ⇣'$upstream_behind ' ⇡'$upstream_ahead
-        set_color $tide_git_color_stash; printf %s ' *'$stash
-        set_color $tide_git_color_conflicted; printf %s ' ~'$conflicted
-        set_color $tide_git_color_staged; printf %s ' +'$staged
-        set_color $tide_git_color_dirty; printf %s ' !'$dirty
-        set_color $tide_git_color_untracked; printf %s ' ?'$untracked)
+        set_color $tide_git_color_upstream; printf %s ' '$tide_git_icon_behind$upstream_behind ' '$tide_git_icon_ahead$upstream_ahead
+        set_color $tide_git_color_stash; printf %s ' '$tide_git_icon_stash$stash
+        set_color $tide_git_color_conflicted; printf %s ' '$tide_git_icon_conflicted$conflicted
+        set_color $tide_git_color_staged; printf %s ' '$tide_git_icon_staged$staged
+        set_color $tide_git_color_dirty; printf %s ' '$tide_git_icon_dirty$dirty
+        set_color $tide_git_color_untracked; printf %s ' '$tide_git_icon_untracked$untracked)
 end

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -30,6 +30,13 @@ tide_git_color_stash $_tide_color_green
 tide_git_color_untracked $_tide_color_light_blue
 tide_git_color_upstream $_tide_color_green
 tide_git_icon
+tide_git_icon_ahead '⇡'
+tide_git_icon_behind '⇣'
+tide_git_icon_conflicted '~'
+tide_git_icon_dirty '!'
+tide_git_icon_staged '+'
+tide_git_icon_stash '*'
+tide_git_icon_untracked '?'
 tide_go_bg_color 444444
 tide_go_color 00ACD7
 tide_go_icon 

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -30,6 +30,13 @@ tide_git_color_stash $_tide_color_green
 tide_git_color_untracked $_tide_color_light_blue
 tide_git_color_upstream $_tide_color_green
 tide_git_icon
+tide_git_icon_ahead '⇡'
+tide_git_icon_behind '⇣'
+tide_git_icon_conflicted '~'
+tide_git_icon_dirty '!'
+tide_git_icon_staged '+'
+tide_git_icon_stash '*'
+tide_git_icon_untracked '?'
 tide_go_bg_color normal
 tide_go_color 00ACD7
 tide_go_icon 

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -30,6 +30,13 @@ tide_git_color_stash 000000
 tide_git_color_untracked 000000
 tide_git_color_upstream 000000
 tide_git_icon
+tide_git_icon_ahead '⇡'
+tide_git_icon_behind '⇣'
+tide_git_icon_conflicted '~'
+tide_git_icon_dirty '!'
+tide_git_icon_staged '+'
+tide_git_icon_stash '*'
+tide_git_icon_untracked '?'
 tide_go_bg_color 00ACD7
 tide_go_color 000000
 tide_go_icon 


### PR DESCRIPTION
Makes git prompt icons configurable through variables.

#### Description

Adds the following variables:
* `tide_git_icon_ahead '⇡'`
* `tide_git_icon_behind '⇣'`
* `tide_git_icon_conflicted '~'`
* `tide_git_icon_dirty '!'`
* `tide_git_icon_staged '+'`
* `tide_git_icon_stash '*'`
* `tide_git_icon_untracked '?'`

#### How Has This Been Tested

I use Tide with this patch and custom icons. I didn't see any problem.

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I have updated the documentation accordingly. 
**I'll update the wiki, if merged.**
- [ ] I have updated the tests accordingly. 
**Other prompt items do not test icon configurability either.**
