### PR TITLE
Make Vi insert mode configurable

### DIFF
--- a/functions/_tide_item_vi_mode.fish
+++ b/functions/_tide_item_vi_mode.fish
@@ -3,6 +3,9 @@ function _tide_item_vi_mode
         case default
             tide_vi_mode_bg_color=$tide_vi_mode_bg_color_default tide_vi_mode_color=$tide_vi_mode_color_default \
                 _tide_print_item vi_mode $tide_vi_mode_icon_default
+        case insert
+            tide_vi_mode_bg_color=$tide_vi_mode_bg_color_insert tide_vi_mode_color=$tide_vi_mode_color_insert \
+                _tide_print_item vi_mode $tide_vi_mode_icon_insert
         case replace replace_one
             tide_vi_mode_bg_color=$tide_vi_mode_bg_color_replace tide_vi_mode_color=$tide_vi_mode_color_replace \
                 _tide_print_item vi_mode $tide_vi_mode_icon_replace

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -90,15 +90,15 @@ tide_time_bg_color 444444
 tide_time_color 5F8787
 tide_time_format '%T'
 tide_vi_mode_bg_color_default 444444
-tide_vi_mode_bg_color_insert 444444
+tide_vi_mode_bg_color_insert
 tide_vi_mode_bg_color_replace 444444
 tide_vi_mode_bg_color_visual 444444
 tide_vi_mode_color_default 87af00
-tide_vi_mode_color_insert 8787af
+tide_vi_mode_color_insert
 tide_vi_mode_color_replace d78700
 tide_vi_mode_color_visual 5f87d7
 tide_vi_mode_icon_default DEFAULT
-tide_vi_mode_icon_insert INSERT
+tide_vi_mode_icon_insert
 tide_vi_mode_icon_replace REPLACE
 tide_vi_mode_icon_visual VISUAL
 tide_virtual_env_bg_color 444444

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -90,12 +90,15 @@ tide_time_bg_color 444444
 tide_time_color 5F8787
 tide_time_format '%T'
 tide_vi_mode_bg_color_default 444444
+tide_vi_mode_bg_color_insert 444444
 tide_vi_mode_bg_color_replace 444444
 tide_vi_mode_bg_color_visual 444444
 tide_vi_mode_color_default 87af00
+tide_vi_mode_color_insert 8787af
 tide_vi_mode_color_replace d78700
 tide_vi_mode_color_visual 5f87d7
 tide_vi_mode_icon_default DEFAULT
+tide_vi_mode_icon_insert INSERT
 tide_vi_mode_icon_replace REPLACE
 tide_vi_mode_icon_visual VISUAL
 tide_virtual_env_bg_color 444444

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -49,11 +49,11 @@ tide_status_color_failure red
 tide_time_bg_color black
 tide_time_color brblack
 tide_vi_mode_bg_color_default black
-tide_vi_mode_bg_color_insert black
+tide_vi_mode_bg_color_insert
 tide_vi_mode_bg_color_replace black
 tide_vi_mode_bg_color_visual black
 tide_vi_mode_color_default green
-tide_vi_mode_color_insert magenta
+tide_vi_mode_color_insert
 tide_vi_mode_color_replace yellow
 tide_vi_mode_color_visual blue
 tide_virtual_env_bg_color black

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -49,9 +49,11 @@ tide_status_color_failure red
 tide_time_bg_color black
 tide_time_color brblack
 tide_vi_mode_bg_color_default black
+tide_vi_mode_bg_color_insert black
 tide_vi_mode_bg_color_replace black
 tide_vi_mode_bg_color_visual black
 tide_vi_mode_color_default green
+tide_vi_mode_color_insert magenta
 tide_vi_mode_color_replace yellow
 tide_vi_mode_color_visual blue
 tide_virtual_env_bg_color black

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -90,12 +90,15 @@ tide_time_bg_color normal
 tide_time_color 5F8787
 tide_time_format '%T'
 tide_vi_mode_bg_color_default
+tide_vi_mode_bg_color_insert
 tide_vi_mode_bg_color_replace
 tide_vi_mode_bg_color_visual
 tide_vi_mode_color_default
+tide_vi_mode_color_insert
 tide_vi_mode_color_replace
 tide_vi_mode_color_visual
 tide_vi_mode_icon_default
+tide_vi_mode_icon_insert
 tide_vi_mode_icon_replace
 tide_vi_mode_icon_visual
 tide_virtual_env_bg_color normal

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -49,9 +49,11 @@ tide_status_color_failure red
 tide_time_bg_color normal
 tide_time_color brblack
 tide_vi_mode_bg_color_default normal
+tide_vi_mode_bg_color_insert normal
 tide_vi_mode_bg_color_replace normal
 tide_vi_mode_bg_color_visual normal
 tide_vi_mode_color_default green
+tide_vi_mode_color_insert magenta
 tide_vi_mode_color_replace yellow
 tide_vi_mode_color_visual blue
 tide_virtual_env_bg_color normal

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -49,11 +49,11 @@ tide_status_color_failure red
 tide_time_bg_color normal
 tide_time_color brblack
 tide_vi_mode_bg_color_default normal
-tide_vi_mode_bg_color_insert normal
+tide_vi_mode_bg_color_insert
 tide_vi_mode_bg_color_replace normal
 tide_vi_mode_bg_color_visual normal
 tide_vi_mode_color_default green
-tide_vi_mode_color_insert magenta
+tide_vi_mode_color_insert
 tide_vi_mode_color_replace yellow
 tide_vi_mode_color_visual blue
 tide_virtual_env_bg_color normal

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -90,15 +90,15 @@ tide_time_bg_color D3D7CF
 tide_time_color 000000
 tide_time_format '%T'
 tide_vi_mode_bg_color_default 008000
-tide_vi_mode_bg_color_insert 800080
+tide_vi_mode_bg_color_insert
 tide_vi_mode_bg_color_replace 808000
 tide_vi_mode_bg_color_visual 000080
 tide_vi_mode_color_default 000000
-tide_vi_mode_color_insert 000000
+tide_vi_mode_color_insert
 tide_vi_mode_color_replace 000000
 tide_vi_mode_color_visual 000000
 tide_vi_mode_icon_default DEFAULT
-tide_vi_mode_icon_insert INSERT
+tide_vi_mode_icon_insert
 tide_vi_mode_icon_replace REPLACE
 tide_vi_mode_icon_visual VISUAL
 tide_virtual_env_bg_color 444444

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -90,12 +90,15 @@ tide_time_bg_color D3D7CF
 tide_time_color 000000
 tide_time_format '%T'
 tide_vi_mode_bg_color_default 008000
+tide_vi_mode_bg_color_insert 800080
 tide_vi_mode_bg_color_replace 808000
 tide_vi_mode_bg_color_visual 000080
 tide_vi_mode_color_default 000000
+tide_vi_mode_color_insert 000000
 tide_vi_mode_color_replace 000000
 tide_vi_mode_color_visual 000000
 tide_vi_mode_icon_default DEFAULT
+tide_vi_mode_icon_insert INSERT
 tide_vi_mode_icon_replace REPLACE
 tide_vi_mode_icon_visual VISUAL
 tide_virtual_env_bg_color 444444

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -49,11 +49,11 @@ tide_status_color_failure bryellow
 tide_time_bg_color white
 tide_time_color black
 tide_vi_mode_bg_color_default green
-tide_vi_mode_bg_color_insert magenta
+tide_vi_mode_bg_color_insert
 tide_vi_mode_bg_color_replace yellow
 tide_vi_mode_bg_color_visual blue
 tide_vi_mode_color_default black
-tide_vi_mode_color_insert black
+tide_vi_mode_color_insert
 tide_vi_mode_color_replace black
 tide_vi_mode_color_visual black
 tide_virtual_env_bg_color brblack

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -49,9 +49,11 @@ tide_status_color_failure bryellow
 tide_time_bg_color white
 tide_time_color black
 tide_vi_mode_bg_color_default green
+tide_vi_mode_bg_color_insert magenta
 tide_vi_mode_bg_color_replace yellow
 tide_vi_mode_bg_color_visual blue
 tide_vi_mode_color_default black
+tide_vi_mode_color_insert black
 tide_vi_mode_color_replace black
 tide_vi_mode_color_visual black
 tide_virtual_env_bg_color brblack


### PR DESCRIPTION
Make the color and icon of Vi insert mode configurable.

#### Description

Vi insert mode's color and icon used to be configurable before the version 5 rewrite. I have restored the functionality via the following variables:

* `tide_vi_mode_bg_color_insert`
* `tide_vi_mode_color_insert`
* `tide_vi_mode_icon_insert`

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### Motivation and Context

By default, the insert mode is invisible, making the whole prompt shift when switching to a different mode. This change lets people who find such behavior distracting to make insert mode visible at all times.

#### How Has This Been Tested

I am using Tide with this patch and insert mode configured to be visible and I have not noticed any buggy behavior.

- [X] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

- [ ] I have updated the documentation accordingly.
**I'll update wiki, if the change is merged.**
- [ ] I have updated the tests accordingly.
**Other prompt items do not test for color or icon configurability either.**
