### PR TITLE
add ws integration

### DIFF
--- a/functions/_tide_item_ws.fish
+++ b/functions/_tide_item_ws.fish
@@ -1,3 +1,3 @@
 function _tide_item_ws
-    test -n "$WS_ENVIRONMENT" && _tide_print_item node $tide_ws_icon' ' (ws show)
+    test -n "$WS_ENVIRONMENT" && _tide_print_item ws $tide_ws_icon' ' (ws show)
 end

--- a/functions/_tide_item_ws.fish
+++ b/functions/_tide_item_ws.fish
@@ -1,0 +1,3 @@
+function _tide_item_ws
+    test -n "$WS_ENVIRONMENT" && _tide_print_item node $tide_ws_icon' ' (ws show)
+end

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -101,4 +101,6 @@ tide_vi_mode_icon_visual VISUAL
 tide_virtual_env_bg_color 444444
 tide_virtual_env_color 00AFAF
 tide_virtual_env_icon ''
+tide_ws_bg_color 0000FF
+tide_ws_color FFFFFF
 tide_ws_icon 'ﮂ'

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -101,6 +101,6 @@ tide_vi_mode_icon_visual VISUAL
 tide_virtual_env_bg_color 444444
 tide_virtual_env_color 00AFAF
 tide_virtual_env_icon ''
-tide_ws_bg_color 0000FF
-tide_ws_color FFFFFF
+tide_ws_bg_color FF58BF
+tide_ws_color 000000
 tide_ws_icon 'ﮂ'

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -68,7 +68,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable ''
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc php chruby go kubectl vi_mode
+tide_right_prompt_items status cmd_duration context jobs ws node virtual_env rustc php chruby go kubectl vi_mode
 tide_right_prompt_prefix ''
 tide_right_prompt_separator_diff_color ''
 tide_right_prompt_separator_same_color ''
@@ -101,3 +101,4 @@ tide_vi_mode_icon_visual VISUAL
 tide_virtual_env_bg_color 444444
 tide_virtual_env_color 00AFAF
 tide_virtual_env_icon ''
+tide_ws_icon 'ﮂ'

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -56,6 +56,6 @@ tide_vi_mode_color_replace yellow
 tide_vi_mode_color_visual blue
 tide_virtual_env_bg_color black
 tide_virtual_env_color cyan
-tide_ws_bg_color blue
-tide_ws_color brwhite
+tide_ws_bg_color purple
+tide_ws_color black
 tide_ws_icon 'ﮂ'

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -56,4 +56,6 @@ tide_vi_mode_color_replace yellow
 tide_vi_mode_color_visual blue
 tide_virtual_env_bg_color black
 tide_virtual_env_color cyan
+tide_ws_bg_color blue
+tide_ws_color brwhite
 tide_ws_icon 'ﮂ'

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -56,3 +56,4 @@ tide_vi_mode_color_replace yellow
 tide_vi_mode_color_visual blue
 tide_virtual_env_bg_color black
 tide_virtual_env_color cyan
+tide_ws_icon 'ﮂ'

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -68,7 +68,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable ''
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled false
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc php chruby go kubectl
+tide_right_prompt_items status cmd_duration context jobs ws node virtual_env rustc php chruby go kubectl
 tide_right_prompt_prefix ' '
 tide_right_prompt_separator_diff_color ' '
 tide_right_prompt_separator_same_color ' '
@@ -101,3 +101,4 @@ tide_vi_mode_icon_visual
 tide_virtual_env_bg_color normal
 tide_virtual_env_color 00AFAF
 tide_virtual_env_icon ''
+tide_ws_icon 'ﮂ'

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -101,4 +101,6 @@ tide_vi_mode_icon_visual
 tide_virtual_env_bg_color normal
 tide_virtual_env_color 00AFAF
 tide_virtual_env_icon ''
+tide_ws_bg_color 0000FF
+tide_ws_color FFFFFF
 tide_ws_icon 'ﮂ'

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -101,6 +101,6 @@ tide_vi_mode_icon_visual
 tide_virtual_env_bg_color normal
 tide_virtual_env_color 00AFAF
 tide_virtual_env_icon ''
-tide_ws_bg_color 0000FF
-tide_ws_color FFFFFF
+tide_ws_bg_color FF58BF
+tide_ws_color 000000
 tide_ws_icon 'ﮂ'

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -56,3 +56,4 @@ tide_vi_mode_color_replace yellow
 tide_vi_mode_color_visual blue
 tide_virtual_env_bg_color normal
 tide_virtual_env_color cyan
+tide_ws_icon 'ﮂ'

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -56,4 +56,6 @@ tide_vi_mode_color_replace yellow
 tide_vi_mode_color_visual blue
 tide_virtual_env_bg_color normal
 tide_virtual_env_color cyan
+tide_ws_bg_color blue
+tide_ws_color brwhite
 tide_ws_icon 'ﮂ'

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -56,6 +56,6 @@ tide_vi_mode_color_replace yellow
 tide_vi_mode_color_visual blue
 tide_virtual_env_bg_color normal
 tide_virtual_env_color cyan
-tide_ws_bg_color blue
-tide_ws_color brwhite
+tide_ws_bg_color purple
+tide_ws_color black
 tide_ws_icon 'ﮂ'

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -101,4 +101,6 @@ tide_vi_mode_icon_visual VISUAL
 tide_virtual_env_bg_color 444444
 tide_virtual_env_color 00AFAF
 tide_virtual_env_icon ''
+tide_ws_bg_color 0000FF
+tide_ws_color FFFFFF
 tide_ws_icon 'ﮂ'

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -101,6 +101,6 @@ tide_vi_mode_icon_visual VISUAL
 tide_virtual_env_bg_color 444444
 tide_virtual_env_color 00AFAF
 tide_virtual_env_icon ''
-tide_ws_bg_color 0000FF
-tide_ws_color FFFFFF
+tide_ws_bg_color FF58BF
+tide_ws_color 000000
 tide_ws_icon 'ﮂ'

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -68,7 +68,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable ''
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc php chruby go kubectl vi_mode
+tide_right_prompt_items status cmd_duration context jobs ws node virtual_env rustc php chruby go kubectl vi_mode
 tide_right_prompt_prefix ''
 tide_right_prompt_separator_diff_color ''
 tide_right_prompt_separator_same_color ''
@@ -101,3 +101,4 @@ tide_vi_mode_icon_visual VISUAL
 tide_virtual_env_bg_color 444444
 tide_virtual_env_color 00AFAF
 tide_virtual_env_icon ''
+tide_ws_icon 'ﮂ'

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -56,6 +56,6 @@ tide_vi_mode_color_replace black
 tide_vi_mode_color_visual black
 tide_virtual_env_bg_color brblack
 tide_virtual_env_color cyan
-tide_ws_bg_color blue
-tide_ws_color brwhite
+tide_ws_bg_color purple
+tide_ws_color black
 tide_ws_icon 'ﮂ'

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -56,3 +56,4 @@ tide_vi_mode_color_replace black
 tide_vi_mode_color_visual black
 tide_virtual_env_bg_color brblack
 tide_virtual_env_color cyan
+tide_ws_icon 'ﮂ'

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -56,4 +56,6 @@ tide_vi_mode_color_replace black
 tide_vi_mode_color_visual black
 tide_virtual_env_bg_color brblack
 tide_virtual_env_color cyan
+tide_ws_bg_color blue
+tide_ws_color brwhite
 tide_ws_icon 'ﮂ'


### PR DESCRIPTION
Adds support for displaying the current `ws` workspace. `ws` is a flexible workspace switcher which can be configured to run various commands to switch between different environments. Think Kubernetes contexts but for the entire shell. See https://github.com/daveio/ws for more.

#### Description

Add `_tide_item_ws` and `tide_ws_icon`, add `ws` item to configs on the right side next to `node`.