### PR TITLE
Show Conda virtual environment

### DIFF
--- a/functions/_tide_item_virtual_env.fish
+++ b/functions/_tide_item_virtual_env.fish
@@ -9,4 +9,7 @@ function _tide_item_virtual_env
         else
             _tide_print_item virtual_env $tide_virtual_env_icon' ' $split_virtual_env[-1]
         end
+    if test -n "$CONDA_DEFAULT_ENV"
+        _tide_print_item virtual_env $tide_virtual_env_icon' ' $CONDA_DEFAULT_ENV
+    end
 end

--- a/tests/_tide_item_virtual_env.test.fish
+++ b/tests/_tide_item_virtual_env.test.fish
@@ -17,3 +17,10 @@ _virtual_env # CHECK:  python_project
 
 set -lx VIRTUAL_ENV /home/ilan/.local/share/virtualenvs/pipenv_project-EwRYuc3l
 _virtual_env # CHECK:  pipenv_project
+
+set -lx VIRTUAL_ENV
+set -lx CONDA_DEFAULT_ENV
+_virtual_env # CHECK:
+
+set -lx CONDA_DEFAULT_ENV myenv
+_virtual_env # CHECK:  myenv


### PR DESCRIPTION
Show conda virtual environment.

#### Description

Uses the virtual_env item to support Conda environments along regular venvs.

#### Motivation and Context

Several people have been asking for this feature. It closes #194.

#### How Has This Been Tested
 
I have tested this in a Conda container - didn't show the item outside Conda env, showed the corrent enviroment name once I created. The visual style is consistent with regular venvs.

I also tested it with unit tests.

- [X] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I have updated the documentation accordingly.
**I will update the Wiki if merged**
- [X] I have updated the tests accordingly.
