### PR TITLE
Add Terraform item

### DIFF
--- a/functions/_tide_item_terraform.fish
+++ b/functions/_tide_item_terraform.fish
@@ -1,0 +1,3 @@
+function _tide_item_terraform
+    test -d .terraform && _tide_print_item terraform $tide_terraform_icon' ' (terraform workspace show)
+end

--- a/functions/_tide_item_terraform.fish
+++ b/functions/_tide_item_terraform.fish
@@ -1,6 +1,6 @@
 function _tide_item_terraform
     if test -d .terraform
-        set -l workspace (terraform workspace show)
-        test $workspace != 'default' && _tide_print_item terraform $tide_terraform_icon' ' $workspace
+        terraform workspace show | read -l workspace
+        test $workspace != default && _tide_print_item terraform $tide_terraform_icon' ' $workspace
     end
 end

--- a/functions/_tide_item_terraform.fish
+++ b/functions/_tide_item_terraform.fish
@@ -1,3 +1,6 @@
 function _tide_item_terraform
-    test -d .terraform && _tide_print_item terraform $tide_terraform_icon' ' (terraform workspace show)
+    if test -d .terraform
+        set -l workspace (terraform workspace show)
+        test $workspace != 'default' && _tide_print_item terraform $tide_terraform_icon' ' $workspace
+    end
 end

--- a/functions/_tide_remove_unusable_items.fish
+++ b/functions/_tide_remove_unusable_items.fish
@@ -1,6 +1,6 @@
 function _tide_remove_unusable_items
     # Remove tool-specific items for tools the machine doesn't have installed
-    for item in chruby git go kubectl node php rustc virtual_env
+    for item in chruby git go kubectl node php rustc terraform virtual_env
         set -l cli_names $item
         switch $item
             case virtual_env

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -68,7 +68,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable ''
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc php chruby go kubectl vi_mode
+tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc php chruby go kubectl terraform vi_mode
 tide_right_prompt_prefix ''
 tide_right_prompt_separator_diff_color ''
 tide_right_prompt_separator_same_color ''

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -86,6 +86,9 @@ tide_status_color $_tide_color_dark_green
 tide_status_color_failure D70000
 tide_status_icon '✔'
 tide_status_icon_failure '✘'
+tide_terraform_bg_color 444444
+tide_terraform_color 844FBA
+tide_terraform_icon
 tide_time_bg_color 444444
 tide_time_color 5F8787
 tide_time_format '%T'

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -46,6 +46,8 @@ tide_status_bg_color black
 tide_status_bg_color_failure black
 tide_status_color green
 tide_status_color_failure red
+tide_terraform_bg_color black
+tide_terraform_color magenta
 tide_time_bg_color black
 tide_time_color brblack
 tide_vi_mode_bg_color_default black

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -68,7 +68,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable ''
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled false
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc php chruby go kubectl
+tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc php chruby go kubectl terraform
 tide_right_prompt_prefix ' '
 tide_right_prompt_separator_diff_color ' '
 tide_right_prompt_separator_same_color ' '

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -86,6 +86,9 @@ tide_status_color $_tide_color_dark_green
 tide_status_color_failure D70000
 tide_status_icon '✔'
 tide_status_icon_failure '✘'
+tide_terraform_bg_color normal
+tide_terraform_color 844FBA
+tide_terraform_icon
 tide_time_bg_color normal
 tide_time_color 5F8787
 tide_time_format '%T'

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -46,6 +46,8 @@ tide_status_bg_color normal
 tide_status_bg_color_failure normal
 tide_status_color green
 tide_status_color_failure red
+tide_terraform_bg_color normal
+tide_terraform_color magenta
 tide_time_bg_color normal
 tide_time_color brblack
 tide_vi_mode_bg_color_default normal

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -68,7 +68,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable ''
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc php chruby go kubectl vi_mode
+tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc php chruby go kubectl terraform vi_mode
 tide_right_prompt_prefix ''
 tide_right_prompt_separator_diff_color ''
 tide_right_prompt_separator_same_color ''

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -86,6 +86,9 @@ tide_status_color 4E9A06
 tide_status_color_failure FFFF00
 tide_status_icon '✔'
 tide_status_icon_failure '✘'
+tide_terraform_bg_color 800080
+tide_terraform_color 000000
+tide_terraform_icon
 tide_time_bg_color D3D7CF
 tide_time_color 000000
 tide_time_format '%T'

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -46,6 +46,8 @@ tide_status_bg_color black
 tide_status_bg_color_failure red
 tide_status_color green
 tide_status_color_failure bryellow
+tide_terraform_bg_color magenta
+tide_terraform_color black
 tide_time_bg_color white
 tide_time_color black
 tide_vi_mode_bg_color_default green

--- a/tests/_tide_item_terraform.test.fish
+++ b/tests/_tide_item_terraform.test.fish
@@ -12,6 +12,9 @@ mock terraform workspace show "echo 'default'"
 _php # CHECK:
 
 mkdir .terraform
-_php # CHECK: default
+_php # CHECK:
+
+mock terraform workspace show "echo 'test'"
+_php # CHECK: test
 
 rm -r $terraformDir

--- a/tests/_tide_item_terraform.test.fish
+++ b/tests/_tide_item_terraform.test.fish
@@ -1,0 +1,17 @@
+# RUN: %fish %s
+
+function _terraform
+    _tide_decolor (_tide_item_terraform)
+end
+
+set -l terraformDir (mktemp -d)
+cd $terraformDir
+
+mock terraform workspace show "echo 'default'"
+
+_php # CHECK:
+
+mkdir .terraform
+_php # CHECK: default
+
+rm -r $terraformDir

--- a/tests/_tide_item_terraform.test.fish
+++ b/tests/_tide_item_terraform.test.fish
@@ -7,14 +7,13 @@ end
 set -l terraformDir (mktemp -d)
 cd $terraformDir
 
-mock terraform workspace show "echo 'default'"
-
-_php # CHECK:
+mock terraform "workspace show" "echo default"
+_terraform # CHECK:
 
 mkdir .terraform
-_php # CHECK:
+_terraform # CHECK:
 
-mock terraform workspace show "echo 'test'"
-_php # CHECK: test
+mock terraform "workspace show" "echo test"
+_terraform # CHECK: test
 
 rm -r $terraformDir


### PR DESCRIPTION
#### Description

Adds a new item - terraform - to show the terraform workspace. The colors are provisional, I can change them to something different. Terraform does not have an icon in nerd fonts, so I left it undefined.

#### Motivation and Context

For people who work a lot with Terraform, seeing the current workspace may prevent costly mistakes.

#### How Has This Been Tested

Tried with terraform on my installation. Correctly shows current workspace when inside terraform directory and nothing outside of it. I also added unit tests.

- [X] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

- [ ] I have updated the documentation accordingly.
**I will update the wiki if changes are merged**
- [X] I have updated the tests accordingly.
