### PR TITLE
Add item to show username and host

### DIFF
--- a/functions/_tide_item_userhost.fish
+++ b/functions/_tide_item_userhost.fish
@@ -1,0 +1,3 @@
+function _tide_item_userhost
+    _tide_print_item userhost $tide_cmd_duration_icon' ' (set_color yellow; printf '%s@' $USER; set_color --bold yellow; printf '%s' $hostname)
+end


### PR DESCRIPTION
When SSHing across many hosts, it's good to have a clear indicator of where you're logged in. This item displays the `$USER` and `$hostname` as user@hostname.


#### Screenshots (if appropriate)
![Screenshot_2021-10-11_19-48-10](https://user-images.githubusercontent.com/1159183/136761104-289b1794-e692-423c-a305-a0b4653675e3.png)

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
