### PR TITLE
Add gcloud item for Google Cloud Platform

### DIFF
--- a/functions/_tide_item_gcloud.fish
+++ b/functions/_tide_item_gcloud.fish
@@ -1,0 +1,4 @@
+function _tide_item_gcloud
+    set -l project (gcloud config get-value core/project 2>/dev/null) &&
+        _tide_print_item gcloud $tide_gcloud_icon' ' $project
+end

--- a/functions/_tide_remove_unusable_items.fish
+++ b/functions/_tide_remove_unusable_items.fish
@@ -1,6 +1,6 @@
 function _tide_remove_unusable_items
     # Remove tool-specific items for tools the machine doesn't have installed
-    for item in chruby git go kubectl node php rustc terraform virtual_env
+    for item in chruby git go kubectl node php rustc terraform gcloud virtual_env
         set -l cli_names $item
         switch $item
             case virtual_env

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -17,6 +17,9 @@ tide_context_bg_color 444444
 tide_context_color_default D7AF87
 tide_context_color_root $_tide_color_gold
 tide_context_color_ssh D7AF87
+tide_gcloud_bg_color 444444
+tide_gcloud_color 326CE5
+tide_gcloud_icon ''
 tide_git_bg_color 444444
 tide_git_bg_color_unstable 444444
 tide_git_bg_color_urgent 444444
@@ -67,7 +70,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable ''
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc php chruby go kubectl terraform vi_mode
+tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc php chruby go kubectl terraform gcloud vi_mode
 tide_right_prompt_prefix ''
 tide_right_prompt_separator_diff_color ''
 tide_right_prompt_separator_same_color ''

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -8,6 +8,8 @@ tide_context_bg_color black
 tide_context_color_default yellow
 tide_context_color_root bryellow
 tide_context_color_ssh yellow
+tide_gcloud_bg_color black
+tide_gcloud_color blue
 tide_git_bg_color black
 tide_git_bg_color_unstable black
 tide_git_bg_color_urgent black

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -17,6 +17,9 @@ tide_context_bg_color normal
 tide_context_color_default D7AF87
 tide_context_color_root $_tide_color_gold
 tide_context_color_ssh D7AF87
+tide_gcloud_bg_color normal
+tide_gcloud_color 326CE5
+tide_gcloud_icon ''
 tide_git_bg_color normal
 tide_git_bg_color_unstable normal
 tide_git_bg_color_urgent normal
@@ -67,7 +70,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable ''
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled false
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc php chruby go kubectl terraform
+tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc php chruby go kubectl terraform gcloud
 tide_right_prompt_prefix ' '
 tide_right_prompt_separator_diff_color ' '
 tide_right_prompt_separator_same_color ' '

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -8,6 +8,8 @@ tide_context_bg_color normal
 tide_context_color_default yellow
 tide_context_color_root bryellow
 tide_context_color_ssh yellow
+tide_gcloud_bg_color normal
+tide_gcloud_color blue
 tide_git_bg_color normal
 tide_git_bg_color_unstable normal
 tide_git_bg_color_urgent normal
@@ -45,8 +47,6 @@ tide_status_bg_color normal
 tide_status_bg_color_failure normal
 tide_status_color green
 tide_status_color_failure red
-tide_terraform_bg_color normal
-tide_terraform_color magenta
 tide_time_bg_color normal
 tide_time_color brblack
 tide_vi_mode_bg_color_default normal

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -17,6 +17,9 @@ tide_context_bg_color 444444
 tide_context_color_default D7AF87
 tide_context_color_root $_tide_color_gold
 tide_context_color_ssh D7AF87
+tide_gcloud_bg_color 326CE5
+tide_gcloud_color 000000
+tide_gcloud_icon ''
 tide_git_bg_color 4E9A06
 tide_git_bg_color_unstable C4A000
 tide_git_bg_color_urgent CC0000
@@ -67,7 +70,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable ''
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc php chruby go kubectl terraform vi_mode
+tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc php chruby go kubectl terraform gcloud vi_mode
 tide_right_prompt_prefix ''
 tide_right_prompt_separator_diff_color ''
 tide_right_prompt_separator_same_color ''

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -8,6 +8,8 @@ tide_context_bg_color brblack
 tide_context_color_default yellow
 tide_context_color_root yellow
 tide_context_color_ssh yellow
+tide_gcloud_bg_color blue
+tide_gcloud_color black
 tide_git_bg_color green
 tide_git_bg_color_unstable yellow
 tide_git_bg_color_urgent red

--- a/tests/_tide_item_gcloud.test.fish
+++ b/tests/_tide_item_gcloud.test.fish
@@ -1,0 +1,13 @@
+# RUN: %fish %s
+
+function _gcloud
+    _tide_decolor (_tide_item_gcloud)
+end
+
+set -lx tide_gcloud_icon 
+
+mock gcloud \* "echo ERROR: \(gcloud.config.get-value\) Section [core] has no property [project]. >&2; false"
+_gcloud # CHECK:
+
+mock gcloud \* "printf project"
+_gcloud # CHECK:  project


### PR DESCRIPTION
#### Description

Adds a  gcloud item to show the current Google Cloud Platform project.

#### Motivation and Context

I have previously showed the current GCP project in the tmux tab bar but displaying it as an item in the command line reduces the chance of doing operations to the wrong project considerable.

#### Screenshots (if appropriate)

<img width="328" alt="Screenshot 2021-10-28 at 17 43 21" src="https://user-images.githubusercontent.com/821518/139290104-cefe1bcb-e6f8-4dd2-a2b2-232363c912cf.png">

#### How Has This Been Tested

Tested using a real GCP project and the project unit testing.

- [ ] I have tested using **Linux**.
- [x] I have tested using **MacOS**.

#### Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
