### PR TITLE
feat: Add context support for toolbox

### DIFF
--- a/functions/_tide_item_context.fish
+++ b/functions/_tide_item_context.fish
@@ -3,6 +3,8 @@ function _tide_item_context
         tide_context_color=$tide_context_color_ssh _tide_print_item context $USER'@'$hostname
     else if contains -- $USER root toor Administrator
         tide_context_color=$tide_context_color_root _tide_print_item context $USER'@'$hostname
+    else if contains -- $HOSTNAME toolbox and contains -- $TOOLBOX_PATH toolbox
+        tide_context_color=$tide_context_color_root _tide_print_item context $USER'@'$hostname
     else if test "$tide_context_always_display" = true
         tide_context_color=$tide_context_color_default _tide_print_item context $USER'@'$hostname
     end

--- a/functions/_tide_item_context.fish
+++ b/functions/_tide_item_context.fish
@@ -3,7 +3,7 @@ function _tide_item_context
         tide_context_color=$tide_context_color_ssh _tide_print_item context $USER'@'$hostname
     else if contains -- $USER root toor Administrator
         tide_context_color=$tide_context_color_root _tide_print_item context $USER'@'$hostname
-    else if contains -- $HOSTNAME toolbox and contains -- $TOOLBOX_PATH toolbox
+    else if test -f /run/.toolboxenv
         tide_context_color=$tide_context_color_root _tide_print_item context $USER'@'$hostname
     else if test "$tide_context_always_display" = true
         tide_context_color=$tide_context_color_default _tide_print_item context $USER'@'$hostname


### PR DESCRIPTION
#### Description
Adding a context check - if `test -f /run/.toolboxenv` passes, we are in a toolbox, so display `hostname` in `context`. User remains the same.

#### Motivation and Context

Small quality of life change - when using `toolbox` it can be hard to identify where you are, because a `toolbox` shares your /home/ and a lot of host information, but can be treated like a somewhat isolated container by the user.

#### How Has This Been Tested

Tested by entering and exiting a `toolbox` to see if `context` would appear & disappear.

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
