### PR TITLE
Add truncation possibility for git prompt

### DIFF
--- a/conf.d/_tide_init.fish
+++ b/conf.d/_tide_init.fish
@@ -2,6 +2,7 @@ function _tide_init_install --on-event _tide_init_install
     set -U tide_os_icon (_tide_detect_os)
     set -U VIRTUAL_ENV_DISABLE_PROMPT true
     set -U _tide_var_list tide_os_icon VIRTUAL_ENV_DISABLE_PROMPT
+    set -U tide_git_truncation_symbol "…"
 
     source (functions --details _tide_sub_configure)
     _load_config lean

--- a/functions/_tide_item_git.fish
+++ b/functions/_tide_item_git.fish
@@ -1,5 +1,9 @@
 function _tide_item_git
-    set -l location $_tide_location_color(git branch --show-current 2>/dev/null) || return
+    set -l git_branch (git branch --show-current 2>/dev/null) || return
+    if test ! -z "$tide_git_truncation_length"; and test (string length $git_branch) -gt $tide_git_truncation_length
+        set git_branch (string sub -l $tide_git_truncation_length $git_branch)"$tide_git_truncation_symbol"
+    end
+    set -l location $_tide_location_color$git_branch
     # --quiet = don't error if there are no commits
     git rev-parse --quiet --git-dir --is-inside-git-dir --short HEAD |
         read --local --line git_dir is_inside_git_dir sha

--- a/tests/_tide_item_git.test.fish
+++ b/tests/_tide_item_git.test.fish
@@ -56,6 +56,12 @@ _git commit -am 'Append hello to foo'
 _git checkout HEAD~
 _git_item # CHECK: {{@\w*}}
 
+# Long prompts
+_git checkout main
+git branch -m "Looooooong_branchname"
+set tide_git_truncation_length 5
+_git_item # CHECK: Loooo…
+
 # -------- bare repo test --------
 cd $dir/bare-repo
 _git init --bare

--- a/tests/_tide_item_git.test.fish
+++ b/tests/_tide_item_git.test.fish
@@ -58,7 +58,7 @@ _git_item # CHECK: {{@\w*}}
 
 # Long prompts
 _git checkout main
-git branch -m "Looooooong_branchname"
+git branch -m Looooooong_branchname
 set tide_git_truncation_length 5
 _git_item # CHECK: Loooo…
 


### PR DESCRIPTION
#### Description

In case of looong git branch names the prompt fills up the whole screen. This PR introduces variables `tide_git_truncation_length` and `tide_git_truncation_symbol` (predefined to "…") to truncate the git prompt after the given number of characters.

#### How Has This Been Tested

1. Created a long branch name
2. Observed the prompt

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

- [ ] I have updated the documentation accordingly. Variable doumentation is in the Wiki...
- [x] I have updated the tests accordingly.