### PR TITLE
Check if PHP is installed before trying to show version

### DIFF
--- a/functions/_tide_item_php.fish
+++ b/functions/_tide_item_php.fish
@@ -1,3 +1,3 @@
 function _tide_item_php
-    test -e composer.json && _tide_print_item php $tide_php_icon' ' (php --version | string match --regex 'PHP ([\d.]+)')[2]
+    test -e composer.json && which php && _tide_print_item php $tide_php_icon' ' (php --version | string match --regex 'PHP ([\d.]+)')[2]
 end


### PR DESCRIPTION
When browsing to a directory with `composer.json` without PHP installed, you get this error on every prompt:
```
❯ fish: Unknown command: php
~/.config/fish/functions/_tide_item_php.fish (line 1):
php --version | string match --regex 'PHP ([\d.]+)'
^
in command substitution
	called on line 2 of file ~/.config/fish/functions/_tide_item_php.fish
in function '_tide_item_php'
	called on line 34 of file ~/.config/fish/functions/_tide_prompt.fish
in function '_tide_left_prompt'
	called on line 1 of file ~/.config/fish/functions/_tide_prompt.fish
in command substitution
	called on line 2 of file ~/.config/fish/functions/_tide_prompt.fish
in function '_tide_prompt'
in command substitution
~/.config/fish/functions/_tide_item_php.fish (line 2): Unknown command
    test -e composer.json && _tide_print_item php $tide_php_icon' ' (php --version | string match --regex 'PHP ([\d.]+)')[2]
                                                                    ^
in function '_tide_item_php'
	called on line 34 of file ~/.config/fish/functions/_tide_prompt.fish
in function '_tide_left_prompt'
	called on line 1 of file ~/.config/fish/functions/_tide_prompt.fish
in command substitution
	called on line 2 of file ~/.config/fish/functions/_tide_prompt.fish
in function '_tide_prompt'
in command substitution
```

This should fix that.

I think this same principle should be applied to all other commands too. What do you think?
