### PR TITLE
java support for tide

### DIFF
--- a/functions/_tide_item_java.fish
+++ b/functions/_tide_item_java.fish
@@ -1,0 +1,3 @@
+function _tide_item_java
+    test -e pom.xml && _tide_print_item java $tide_java_icon' ' (set jv (java -version 2>&1 | head -1 | string split ' ')[3]; echo $jv | string trim -c '"')
+end

--- a/functions/_tide_item_java.fish
+++ b/functions/_tide_item_java.fish
@@ -1,3 +1,3 @@
 function _tide_item_java
-    test -e pom.xml && _tide_print_item java $tide_java_icon' ' (set jv (java -version 2>&1 | head -1 | string split ' ')[3]; echo $jv | string trim -c '"')
+    test -e pom.xml && _tide_print_item java $tide_java_icon' ' (java --version | string split ' ')[2]
 end

--- a/functions/_tide_remove_unusable_items.fish
+++ b/functions/_tide_remove_unusable_items.fish
@@ -1,6 +1,6 @@
 function _tide_remove_unusable_items
     # Remove tool-specific items for tools the machine doesn't have installed
-    for item in chruby git go kubectl node php rustc terraform virtual_env
+    for item in chruby git go kubectl node php rustc java terraform virtual_env
         set -l cli_names $item
         switch $item
             case virtual_env

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -67,7 +67,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable ''
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc php chruby go kubectl terraform vi_mode
+tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php chruby go kubectl terraform vi_mode
 tide_right_prompt_prefix ''
 tide_right_prompt_separator_diff_color ''
 tide_right_prompt_separator_same_color ''
@@ -75,6 +75,9 @@ tide_right_prompt_suffix ''
 tide_rustc_bg_color 444444
 tide_rustc_color F74C00
 tide_rustc_icon ''
+tide_java_bg_color 444444
+tide_java_color F74C00
+tide_java_icon ''
 tide_shlvl_bg_color 444444
 tide_shlvl_color d78700
 tide_shlvl_icon ''

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -32,6 +32,9 @@ tide_git_icon
 tide_go_bg_color 444444
 tide_go_color 00ACD7
 tide_go_icon 
+tide_java_bg_color 444444
+tide_java_color ED8B00
+tide_java_icon ''
 tide_jobs_bg_color 444444
 tide_jobs_color $_tide_color_dark_green
 tide_jobs_icon ''
@@ -75,9 +78,6 @@ tide_right_prompt_suffix ''
 tide_rustc_bg_color 444444
 tide_rustc_color F74C00
 tide_rustc_icon ''
-tide_java_bg_color 444444
-tide_java_color F74C00
-tide_java_icon ''
 tide_shlvl_bg_color 444444
 tide_shlvl_color d78700
 tide_shlvl_icon ''

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -21,6 +21,8 @@ tide_git_color_untracked brblue
 tide_git_color_upstream brgreen
 tide_go_bg_color black
 tide_go_color brcyan
+tide_java_bg_color black
+tide_java_color yellow
 tide_jobs_bg_color black
 tide_jobs_color green
 tide_kubectl_bg_color black
@@ -39,8 +41,6 @@ tide_pwd_color_dirs cyan
 tide_pwd_color_truncated_dirs magenta
 tide_rustc_bg_color black
 tide_rustc_color red
-tide_java_bg_color black
-tide_java_color red
 tide_shlvl_bg_color black
 tide_shlvl_color yellow
 tide_status_bg_color black

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -39,6 +39,8 @@ tide_pwd_color_dirs cyan
 tide_pwd_color_truncated_dirs magenta
 tide_rustc_bg_color black
 tide_rustc_color red
+tide_java_bg_color black
+tide_java_color red
 tide_shlvl_bg_color black
 tide_shlvl_color yellow
 tide_status_bg_color black

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -32,6 +32,9 @@ tide_git_icon
 tide_go_bg_color normal
 tide_go_color 00ACD7
 tide_go_icon 
+tide_java_bg_color normal
+tide_java_color ED8B00
+tide_java_icon ''
 tide_jobs_bg_color normal
 tide_jobs_color $_tide_color_dark_green
 tide_jobs_icon ''
@@ -75,9 +78,6 @@ tide_right_prompt_suffix ''
 tide_rustc_bg_color normal
 tide_rustc_color F74C00
 tide_rustc_icon ''
-tide_java_bg_color normal
-tide_java_color F74C00
-tide_java_icon ''
 tide_shlvl_bg_color normal
 tide_shlvl_color d78700
 tide_shlvl_icon ''

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -67,7 +67,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable ''
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled false
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc php chruby go kubectl terraform
+tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php chruby go kubectl terraform
 tide_right_prompt_prefix ' '
 tide_right_prompt_separator_diff_color ' '
 tide_right_prompt_separator_same_color ' '
@@ -75,6 +75,9 @@ tide_right_prompt_suffix ''
 tide_rustc_bg_color normal
 tide_rustc_color F74C00
 tide_rustc_icon ''
+tide_java_bg_color normal
+tide_java_color F74C00
+tide_java_icon ''
 tide_shlvl_bg_color normal
 tide_shlvl_color d78700
 tide_shlvl_icon ''

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -21,6 +21,8 @@ tide_git_color_untracked brblue
 tide_git_color_upstream brgreen
 tide_go_bg_color normal
 tide_go_color brcyan
+tide_java_bg_color normal
+tide_java_color yellow
 tide_jobs_bg_color normal
 tide_jobs_color green
 tide_kubectl_bg_color normal
@@ -39,8 +41,6 @@ tide_pwd_color_dirs cyan
 tide_pwd_color_truncated_dirs magenta
 tide_rustc_bg_color normal
 tide_rustc_color red
-tide_java_bg_color normal
-tide_java_color red
 tide_shlvl_bg_color normal
 tide_shlvl_color yellow
 tide_status_bg_color normal

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -39,6 +39,8 @@ tide_pwd_color_dirs cyan
 tide_pwd_color_truncated_dirs magenta
 tide_rustc_bg_color normal
 tide_rustc_color red
+tide_java_bg_color normal
+tide_java_color red
 tide_shlvl_bg_color normal
 tide_shlvl_color yellow
 tide_status_bg_color normal

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -67,7 +67,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable ''
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc php chruby go kubectl terraform vi_mode
+tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php chruby go kubectl terraform vi_mode
 tide_right_prompt_prefix ''
 tide_right_prompt_separator_diff_color ''
 tide_right_prompt_separator_same_color ''
@@ -75,6 +75,9 @@ tide_right_prompt_suffix ''
 tide_rustc_bg_color F74C00
 tide_rustc_color 000000
 tide_rustc_icon ''
+tide_java_bg_color F74C00
+tide_java_color 000000
+tide_java_icon ''
 tide_shlvl_bg_color 808000
 tide_shlvl_color 000000
 tide_shlvl_icon ''

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -32,6 +32,9 @@ tide_git_icon
 tide_go_bg_color 00ACD7
 tide_go_color 000000
 tide_go_icon 
+tide_java_bg_color ED8B00
+tide_java_color 000000
+tide_java_icon ''
 tide_jobs_bg_color 444444
 tide_jobs_color 4E9A06
 tide_jobs_icon ''
@@ -75,9 +78,6 @@ tide_right_prompt_suffix ''
 tide_rustc_bg_color F74C00
 tide_rustc_color 000000
 tide_rustc_icon ''
-tide_java_bg_color F74C00
-tide_java_color 000000
-tide_java_icon ''
 tide_shlvl_bg_color 808000
 tide_shlvl_color 000000
 tide_shlvl_icon ''

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -39,6 +39,8 @@ tide_pwd_color_dirs brwhite
 tide_pwd_color_truncated_dirs white
 tide_rustc_bg_color red
 tide_rustc_color black
+tide_java_bg_color red
+tide_java_color black
 tide_shlvl_bg_color yellow
 tide_shlvl_color black
 tide_status_bg_color black

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -21,6 +21,8 @@ tide_git_color_untracked black
 tide_git_color_upstream black
 tide_go_bg_color brcyan
 tide_go_color black
+tide_java_bg_color yellow
+tide_java_color black
 tide_jobs_bg_color brblack
 tide_jobs_color green
 tide_kubectl_bg_color blue
@@ -39,8 +41,6 @@ tide_pwd_color_dirs brwhite
 tide_pwd_color_truncated_dirs white
 tide_rustc_bg_color red
 tide_rustc_color black
-tide_java_bg_color red
-tide_java_color black
 tide_shlvl_bg_color yellow
 tide_shlvl_color black
 tide_status_bg_color black

--- a/tests/_tide_item_java.test.fish
+++ b/tests/_tide_item_java.test.fish
@@ -1,0 +1,21 @@
+# RUN: %fish %s
+
+function _java
+    _tide_decolor (_tide_item_java)
+end
+
+set -l javaDir (mktemp -d)
+cd $javaDir
+
+mock java --version "echo 'openjdk 17.0.1 2021-10-19
+OpenJDK Runtime Environment (build 17.0.1+12)
+OpenJDK 64-Bit Server VM (build 17.0.1+12, mixed mode)'"
+
+set -lx tide_java_icon 
+
+_java # CHECK:
+
+touch pom.xml
+_java # CHECK:  17.0.1
+
+rm -r $javaDir


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Support right_prompt item to identify java version (adding a _tide_item_java.fish) to reflect java if there's a pom.xml file for maven

<!-- Describe your changes. -->

Add _tide_item_java.fish and update config variables with colors and icons for java based on Nerd Fonts.

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Support identify version when java is running

Closes # <!--- Please link to an open issue. -->

#### Screenshots (if appropriate)

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [x] I have tested using **Linux**.
- [v] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ x] I have updated the documentation accordingly.
- [ x] I have updated the tests accordingly.
