### PR TITLE
Don't omit last suffix in 2-line prompts

### DIFF
--- a/functions/_tide_2_line_prompt.fish
+++ b/functions/_tide_2_line_prompt.fish
@@ -3,12 +3,20 @@ function _tide_2_line_prompt
     _tide_side=left for item in $_tide_left_items
         _tide_item_$item
     end
+    if not set -e add_prefix
+        set_color $prev_bg_color -b normal
+        echo $tide_left_prompt_suffix
+    end
 
     echo
 
     set -g add_prefix
     _tide_side=right for item in $_tide_right_items
         _tide_item_$item
+    end
+    if not set -e add_prefix
+        set_color $prev_bg_color -b normal
+        echo $tide_right_prompt_suffix
     end
 end
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Description

This previously was in `_tide_prompt.fish` line 36 and 51 but apparently not brought over to the new branch?

I think this PR replicates the original behavior of only adding the suffix on the second line if there is at least one item on the line (`add_prefix` being the new `_tide_last_item_was_newline`).

Feel free to let me know if i'm missing something.

#### How Has This Been Tested

tested with 2-line prompts both with and without items on the second line after the `'newline'` item.

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
