### PR TITLE
Add Android icon

### DIFF
--- a/functions/_tide_detect_os.fish
+++ b/functions/_tide_detect_os.fish
@@ -7,12 +7,15 @@ function _tide_detect_os
         case freebsd openbsd dragonfly
             printf %s\n  FFFFFF AB2B28 # https://freebsdfoundation.org/about-us/about-the-foundation/project/
         case linux
-            # android logo from https://developer.android.com/distribute/marketing-tools/brand-guidelines
-            uname -o | string match -eq Android && printf %s\n  3DDC84 FFFFFF ||
+            if test (uname -o) = Android
+                # https://developer.android.com/distribute/marketing-tools/brand-guidelines
+                printf %s\n  3DDC84 3C3F41 # fg is from above link, bg is Android Studio Darcula
+            else
                 _tide_detect_os_linux_cases /etc/os-release ID ||
-                _tide_detect_os_linux_cases /etc/os-release ID_LIKE ||
-                _tide_detect_os_linux_cases /etc/lsb-release DISTRIB_ID ||
-                printf %s\n  $defaultColor
+                    _tide_detect_os_linux_cases /etc/os-release ID_LIKE ||
+                    _tide_detect_os_linux_cases /etc/lsb-release DISTRIB_ID ||
+                    printf %s\n  $defaultColor
+            end
         case '*'
             echo -ns '?'
     end

--- a/functions/_tide_detect_os.fish
+++ b/functions/_tide_detect_os.fish
@@ -7,7 +7,9 @@ function _tide_detect_os
         case freebsd openbsd dragonfly
             printf %s\n  FFFFFF AB2B28 # https://freebsdfoundation.org/about-us/about-the-foundation/project/
         case linux
-            _tide_detect_os_linux_cases /etc/os-release ID ||
+            # android logo from https://developer.android.com/distribute/marketing-tools/brand-guidelines
+            uname -o | string match -eq Android && printf %s\n  3DDC84 FFFFFF ||
+                _tide_detect_os_linux_cases /etc/os-release ID ||
                 _tide_detect_os_linux_cases /etc/os-release ID_LIKE ||
                 _tide_detect_os_linux_cases /etc/lsb-release DISTRIB_ID ||
                 printf %s\n  $defaultColor

--- a/functions/_tide_detect_os.fish
+++ b/functions/_tide_detect_os.fish
@@ -9,7 +9,7 @@ function _tide_detect_os
         case linux
             if test (uname -o) = Android
                 # https://developer.android.com/distribute/marketing-tools/brand-guidelines
-                printf %s\n  3DDC84 3C3F41 # fg is from above link, bg is Android Studio Darcula
+                printf %s\n  3DDC84 3C3F41 # fg is from above link, bg is from Android Studio "Darcula"
             else
                 _tide_detect_os_linux_cases /etc/os-release ID ||
                     _tide_detect_os_linux_cases /etc/os-release ID_LIKE ||

--- a/functions/_tide_detect_os.fish
+++ b/functions/_tide_detect_os.fish
@@ -9,7 +9,7 @@ function _tide_detect_os
         case linux
             if test (uname -o) = Android
                 # https://developer.android.com/distribute/marketing-tools/brand-guidelines
-                printf %s\n  3DDC84 3C3F41 # fg is from above link, bg is from Android Studio "Darcula"
+                printf %s\n  3DDC84 3C3F41 # fg is from above link, bg is from Android Studio default dark theme
             else
                 _tide_detect_os_linux_cases /etc/os-release ID ||
                     _tide_detect_os_linux_cases /etc/os-release ID_LIKE ||

--- a/tests/detect_os/_tide_detect_os.test.fish
+++ b/tests/detect_os/_tide_detect_os.test.fish
@@ -7,12 +7,12 @@ _tide_detect_os
 # CHECK: D6D6D6
 # CHECK: 333333
 
-mock uname -o "echo Android"
 mock uname \* "echo Linux"
+mock uname -o "echo Android"
 _tide_detect_os
 # CHECK: 
 # CHECK: 3DDC84
-# CHECK: FFFFFF
+# CHECK: 3C3F41
 
 function _detect_os_linux_cases -a file
     set -l dir (status dirname)

--- a/tests/detect_os/_tide_detect_os.test.fish
+++ b/tests/detect_os/_tide_detect_os.test.fish
@@ -7,6 +7,13 @@ _tide_detect_os
 # CHECK: D6D6D6
 # CHECK: 333333
 
+mock uname -o "echo Android"
+mock uname \* "echo Linux"
+_tide_detect_os
+# CHECK: 
+# CHECK: 3DDC84
+# CHECK: FFFFFF
+
 function _detect_os_linux_cases -a file
     set -l dir (status dirname)
     _tide_detect_os_linux_cases $dir/$file ID ||


### PR DESCRIPTION
#### Description

Detect and show Android logo on system reporting `Android` in output of `uname -o`. Fixes #286.