### PR TITLE
Add aws item

### DIFF
--- a/functions/_tide_item_aws.fish
+++ b/functions/_tide_item_aws.fish
@@ -1,14 +1,11 @@
 function _tide_item_aws
-    # AWS_PROFILE overrides AWS_DEFAULT_PROFILE
-    set -q AWS_DEFAULT_PROFILE && set -f _profile_name $AWS_DEFAULT_PROFILE
-    set -q AWS_PROFILE && set -f _profile_name $AWS_PROFILE
-    # AWS_REGION overrides AWS_DEFAULT_REGION
-    set -q AWS_DEFAULT_REGION && set -f _region_name $AWS_DEFAULT_REGION
-    set -q AWS_REGION && set -f _region_name $AWS_REGION
+    # AWS_PROFILE overrides AWS_DEFAULT_PROFILE, AWS_REGION overrides AWS_DEFAULT_REGION
+    set -q AWS_PROFILE && set -l AWS_DEFAULT_PROFILE $AWS_PROFILE
+    set -q AWS_REGION && set -l AWS_DEFAULT_REGION $AWS_REGION
 
-    if test -n "$_profile_name" && test -n "$_region_name"
-        _tide_print_item aws $tide_aws_icon' ' "$_profile_name"/"$_region_name"
-    else if test -n "$_profile_name" || test -n "$_region_name"
-        _tide_print_item aws $tide_aws_icon' ' "$_profile_name""$_region_name"
+    if test -n "$AWS_DEFAULT_PROFILE" && test -n "$AWS_DEFAULT_REGION"
+        _tide_print_item aws $tide_aws_icon' ' "$AWS_DEFAULT_PROFILE/$AWS_DEFAULT_REGION"
+    else if test -n "$AWS_DEFAULT_PROFILE$AWS_DEFAULT_REGION"
+        _tide_print_item aws $tide_aws_icon' ' "$AWS_DEFAULT_PROFILE$AWS_DEFAULT_REGION"
     end
 end

--- a/functions/_tide_item_aws.fish
+++ b/functions/_tide_item_aws.fish
@@ -1,0 +1,14 @@
+function _tide_item_aws
+    # AWS_PROFILE overrides AWS_DEFAULT_PROFILE
+    set -q AWS_DEFAULT_PROFILE && set -f _profile_name $AWS_DEFAULT_PROFILE
+    set -q AWS_PROFILE && set -f _profile_name $AWS_PROFILE
+    # AWS_REGION overrides AWS_DEFAULT_REGION
+    set -q AWS_DEFAULT_REGION && set -f _region_name $AWS_DEFAULT_REGION
+    set -q AWS_REGION && set -f _region_name $AWS_REGION
+
+    if test -n "$_profile_name" && test -n "$_region_name"
+        _tide_print_item aws $tide_aws_icon' ' "$_profile_name"/"$_region_name"
+    else if test -n "$_profile_name" || test -n "$_region_name"
+        _tide_print_item aws $tide_aws_icon' ' "$_profile_name""$_region_name"
+    end
+end

--- a/functions/_tide_remove_unusable_items.fish
+++ b/functions/_tide_remove_unusable_items.fish
@@ -1,7 +1,7 @@
 function _tide_remove_unusable_items
     # Remove tool-specific items for tools the machine doesn't have installed
     set -l removed_items
-    for item in chruby docker git go java kubectl node php rustc terraform toolbox virtual_env
+    for item in aws chruby docker git go java kubectl node php rustc terraform toolbox virtual_env
         set -l cli_names $item
         switch $item
             case virtual_env

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -1,6 +1,6 @@
 tide_aws_bg_color 444444
 tide_aws_color FF9900
-tide_aws_icon a
+tide_aws_icon 
 tide_character_color $_tide_color_green
 tide_character_color_failure FF0000
 tide_character_icon ❯

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -1,3 +1,6 @@
+tide_aws_bg_color 444444
+tide_aws_color FF9900
+tide_aws_icon a
 tide_character_color $_tide_color_green
 tide_character_color_failure FF0000
 tide_character_icon ❯
@@ -79,7 +82,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable 
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php chruby go kubectl toolbox terraform vi_mode
+tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php chruby go kubectl toolbox terraform aws vi_mode
 tide_right_prompt_prefix 
 tide_right_prompt_separator_diff_color 
 tide_right_prompt_separator_same_color 

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -1,3 +1,5 @@
+tide_aws_bg_color black
+tide_aws_color yellow
 tide_character_color brgreen
 tide_character_color_failure brred
 tide_chruby_bg_color black

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -1,6 +1,6 @@
 tide_aws_bg_color normal
 tide_aws_color FF9900
-tide_aws_icon a
+tide_aws_icon 
 tide_character_color $_tide_color_green
 tide_character_color_failure FF0000
 tide_character_icon ❯

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -1,3 +1,6 @@
+tide_aws_bg_color normal
+tide_aws_color FF9900
+tide_aws_icon a
 tide_character_color $_tide_color_green
 tide_character_color_failure FF0000
 tide_character_icon ❯
@@ -79,7 +82,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable 
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled false
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php chruby go kubectl toolbox terraform
+tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php chruby go kubectl toolbox terraform aws
 tide_right_prompt_prefix ' '
 tide_right_prompt_separator_diff_color ' '
 tide_right_prompt_separator_same_color ' '

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -1,3 +1,5 @@
+tide_aws_bg_color normal
+tide_aws_color yellow
 tide_character_color brgreen
 tide_character_color_failure brred
 tide_chruby_bg_color normal

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -1,6 +1,6 @@
 tide_aws_bg_color FF9900
 tide_aws_color 232F3E
-tide_aws_icon a
+tide_aws_icon 
 tide_character_color $_tide_color_green
 tide_character_color_failure FF0000
 tide_character_icon ❯

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -1,3 +1,6 @@
+tide_aws_bg_color FF9900
+tide_aws_color 232F3E
+tide_aws_icon a
 tide_character_color $_tide_color_green
 tide_character_color_failure FF0000
 tide_character_icon ❯
@@ -79,7 +82,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable 
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php chruby go kubectl toolbox terraform vi_mode
+tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php chruby go kubectl toolbox terraform aws vi_mode
 tide_right_prompt_prefix 
 tide_right_prompt_separator_diff_color 
 tide_right_prompt_separator_same_color 

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -1,3 +1,5 @@
+tide_aws_bg_color yellow
+tide_aws_color brblack
 tide_character_color brgreen
 tide_character_color_failure brred
 tide_chruby_bg_color red

--- a/tests/_tide_item_aws.test.fish
+++ b/tests/_tide_item_aws.test.fish
@@ -6,7 +6,7 @@ end
 
 _aws # CHECK:
 
-set -lx tide_aws_icon a
+set -lx tide_aws_icon 
 set -lx AWS_DEFAULT_PROFILE default_profile
 
 _aws # CHECK: a default_profile

--- a/tests/_tide_item_aws.test.fish
+++ b/tests/_tide_item_aws.test.fish
@@ -9,19 +9,19 @@ _aws # CHECK:
 set -lx tide_aws_icon 
 set -lx AWS_DEFAULT_PROFILE default_profile
 
-_aws # CHECK: a default_profile
+_aws # CHECK:  default_profile
 
 set -lx AWS_DEFAULT_REGION default_region
 
-_aws # CHECK: a default_profile/default_region
+_aws # CHECK:  default_profile/default_region
 
 set -lx AWS_PROFILE non_default_profile
 set -lx AWS_REGION non_default_region
 
-_aws # CHECK: a non_default_profile/non_default_region
+_aws # CHECK:  non_default_profile/non_default_region
 
 set -e AWS_REGION
 set -e AWS_PROFILE
 set -e AWS_DEFAULT_PROFILE
 
-_aws # CHECK: a default_region
+_aws # CHECK:  default_region

--- a/tests/_tide_item_aws.test.fish
+++ b/tests/_tide_item_aws.test.fish
@@ -1,0 +1,27 @@
+# RUN: %fish %s
+
+function _aws
+    _tide_decolor (_tide_item_aws)
+end
+
+_aws # CHECK:
+
+set -lx tide_aws_icon a
+set -lx AWS_DEFAULT_PROFILE default_profile
+
+_aws # CHECK: a default_profile
+
+set -lx AWS_DEFAULT_REGION default_region
+
+_aws # CHECK: a default_profile/default_region
+
+set -lx AWS_PROFILE non_default_profile
+set -lx AWS_REGION non_default_region
+
+_aws # CHECK: a non_default_profile/non_default_region
+
+set -e AWS_REGION
+set -e AWS_PROFILE
+set -e AWS_DEFAULT_PROFILE
+
+_aws # CHECK: a default_region


### PR DESCRIPTION
#### Description

Add a new item `aws` to show current value of some environment variables, used to configure aws-cli. These config parameters are current cli profile and region.

#### Motivation and Context

In my job I have to work with many AWS accounts and many AWS regions. I have several pre-configured aws-cli profiles to be able to quick switch between accounts. With **AWS_PROFILE** environment variable I can quick choose right profile to use in current work session. The `aws` item helps to understand at a glance which exactly aws-cli profile are using in exactly terminal tab.

#### How Has This Been Tested

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
