### PR TITLE
add `nix_shell` item

### DIFF
--- a/functions/_tide_item_nix_shell.fish
+++ b/functions/_tide_item_nix_shell.fish
@@ -1,0 +1,3 @@
+function _tide_item_nix_shell
+    set -q IN_NIX_SHELL && _tide_print_item nix_shell $tide_nix_shell_icon' ' $IN_NIX_SHELL
+end

--- a/functions/_tide_remove_unusable_items.fish
+++ b/functions/_tide_remove_unusable_items.fish
@@ -1,11 +1,13 @@
 function _tide_remove_unusable_items
     # Remove tool-specific items for tools the machine doesn't have installed
     set -l removed_items
-    for item in aws chruby docker git go java kubectl node php rustc terraform toolbox virtual_env
+    for item in aws chruby docker git go java kubectl nix_shell node php rustc terraform toolbox virtual_env
         set -l cli_names $item
         switch $item
             case virtual_env
                 set cli_names python python3
+            case nix_shell
+                set cli_names nix nix-shell
         end
         type --query $cli_names || set -a removed_items $item
     end

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -55,6 +55,9 @@ tide_left_prompt_prefix ''
 tide_left_prompt_separator_diff_color 
 tide_left_prompt_separator_same_color 
 tide_left_prompt_suffix 
+tide_nix_shell_bg_color 444444
+tide_nix_shell_color 7EBAE4
+tide_nix_shell_icon 
 tide_node_bg_color 444444
 tide_node_color 44883E
 tide_node_icon ⬢
@@ -82,7 +85,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable 
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php chruby go kubectl toolbox terraform aws vi_mode
+tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php chruby go kubectl toolbox terraform aws nix_shell vi_mode
 tide_right_prompt_prefix 
 tide_right_prompt_separator_diff_color 
 tide_right_prompt_separator_same_color 

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -31,6 +31,8 @@ tide_jobs_bg_color black
 tide_jobs_color green
 tide_kubectl_bg_color black
 tide_kubectl_color blue
+tide_nix_shell_bg_color black
+tide_nix_shell_color blue
 tide_node_bg_color black
 tide_node_color green
 tide_os_bg_color black

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -32,7 +32,7 @@ tide_jobs_color green
 tide_kubectl_bg_color black
 tide_kubectl_color blue
 tide_nix_shell_bg_color black
-tide_nix_shell_color blue
+tide_nix_shell_color brblue
 tide_node_bg_color black
 tide_node_color green
 tide_os_bg_color black

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -55,6 +55,9 @@ tide_left_prompt_prefix ''
 tide_left_prompt_separator_diff_color ' '
 tide_left_prompt_separator_same_color ' '
 tide_left_prompt_suffix ' '
+tide_nix_shell_bg_color normal
+tide_nix_shell_color 7EBAE4
+tide_nix_shell_icon 
 tide_node_bg_color normal
 tide_node_color 44883E
 tide_node_icon ⬢
@@ -82,7 +85,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable 
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled false
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php chruby go kubectl toolbox terraform aws
+tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php chruby go kubectl toolbox terraform aws nix_shell
 tide_right_prompt_prefix ' '
 tide_right_prompt_separator_diff_color ' '
 tide_right_prompt_separator_same_color ' '

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -31,6 +31,8 @@ tide_jobs_bg_color normal
 tide_jobs_color green
 tide_kubectl_bg_color normal
 tide_kubectl_color blue
+tide_nix_shell_bg_color normal
+tide_nix_shell_color blue
 tide_node_bg_color normal
 tide_node_color green
 tide_os_bg_color normal

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -32,7 +32,7 @@ tide_jobs_color green
 tide_kubectl_bg_color normal
 tide_kubectl_color blue
 tide_nix_shell_bg_color normal
-tide_nix_shell_color blue
+tide_nix_shell_color brblue
 tide_node_bg_color normal
 tide_node_color green
 tide_os_bg_color normal

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -55,6 +55,9 @@ tide_left_prompt_prefix ''
 tide_left_prompt_separator_diff_color 
 tide_left_prompt_separator_same_color 
 tide_left_prompt_suffix 
+tide_nix_shell_bg_color 7EBAE4
+tide_nix_shell_color 000000
+tide_nix_shell_icon 
 tide_node_bg_color 44883E
 tide_node_color 000000
 tide_node_icon ⬢
@@ -82,7 +85,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable 
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php chruby go kubectl toolbox terraform aws vi_mode
+tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php chruby go kubectl toolbox terraform aws nix_shell vi_mode
 tide_right_prompt_prefix 
 tide_right_prompt_separator_diff_color 
 tide_right_prompt_separator_same_color 

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -31,7 +31,7 @@ tide_jobs_bg_color brblack
 tide_jobs_color green
 tide_kubectl_bg_color blue
 tide_kubectl_color black
-tide_nix_shell_bg_color blue
+tide_nix_shell_bg_color brblue
 tide_nix_shell_color black
 tide_node_bg_color green
 tide_node_color black

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -31,6 +31,8 @@ tide_jobs_bg_color brblack
 tide_jobs_color green
 tide_kubectl_bg_color blue
 tide_kubectl_color black
+tide_nix_shell_bg_color blue
+tide_nix_shell_color black
 tide_node_bg_color green
 tide_node_color black
 tide_os_bg_color white

--- a/tests/_tide_item_nix_shell.test.fish
+++ b/tests/_tide_item_nix_shell.test.fish
@@ -1,0 +1,18 @@
+# RUN: %fish %s
+
+function _nix_shell
+    _tide_decolor (_tide_item_nix_shell)
+end
+
+set -lx tide_nix_shell_icon 
+set -e IN_NIX_SHELL
+
+_nix_shell # CHECK:
+
+set -lx IN_NIX_SHELL pure
+_nix_shell # CHECK:  pure
+
+set -lx IN_NIX_SHELL impure
+_nix_shell # CHECK:  impure
+
+set -e IN_NIX_SHELL


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Description

This PR adds the prompt item `nix_shell`, which checks and displays the `IN_NIX_SHELL` environment variable.
<!-- Describe your changes. -->

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

This makes the prompt display the shell status of Nix development environments.

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

(I have not tested the test files.)

- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
