### PR TITLE
now with crystal language support

### DIFF
--- a/functions/_tide_item_crystal.fish
+++ b/functions/_tide_item_crystal.fish
@@ -1,0 +1,3 @@
+function _tide_item_crystal
+    test -e shard.yml && _tide_print_item crystal $tide_crystal_icon' ' (crystal --version &| string match -r "[\d.]+")[1]
+end

--- a/functions/_tide_item_crystal.fish
+++ b/functions/_tide_item_crystal.fish
@@ -1,3 +1,3 @@
 function _tide_item_crystal
-    test -e shard.yml && _tide_print_item crystal $tide_crystal_icon' ' (crystal --version &| string match -r "[\d.]+")[1]
+    test -e shard.yml && _tide_print_item crystal $tide_crystal_icon' ' (crystal --version | string match -r "[\d.]+")[1]
 end

--- a/functions/_tide_remove_unusable_items.fish
+++ b/functions/_tide_remove_unusable_items.fish
@@ -1,7 +1,7 @@
 function _tide_remove_unusable_items
     # Remove tool-specific items for tools the machine doesn't have installed
     set -l removed_items
-    for item in aws chruby docker git go java kubectl nix_shell node php rustc terraform toolbox virtual_env
+    for item in aws chruby crystal docker git go java kubectl nix_shell node php rustc terraform toolbox virtual_env
         set -l cli_names $item
         switch $item
             case virtual_env

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -20,8 +20,8 @@ tide_context_bg_color 444444
 tide_context_color_default D7AF87
 tide_context_color_root $_tide_color_gold
 tide_context_color_ssh D7AF87
-tide_crystal_bg_color FFFFFF
-tide_crystal_color 000000
+tide_crystal_bg_color 444444
+tide_crystal_color FFFFFF
 tide_crystal_icon ⬢
 tide_docker_bg_color 444444
 tide_docker_color 2496ED
@@ -88,7 +88,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable 
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php chruby go kubectl toolbox terraform aws nix_shell
+tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php chruby go kubectl toolbox terraform aws nix_shell crystal
 tide_right_prompt_prefix 
 tide_right_prompt_separator_diff_color 
 tide_right_prompt_separator_same_color 

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -20,6 +20,9 @@ tide_context_bg_color 444444
 tide_context_color_default D7AF87
 tide_context_color_root $_tide_color_gold
 tide_context_color_ssh D7AF87
+tide_crystal_bg_color FFFFFF
+tide_crystal_color 000000
+tide_crystal_icon ⬢
 tide_docker_bg_color 444444
 tide_docker_color 2496ED
 tide_docker_default_contexts default colima

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -10,8 +10,8 @@ tide_context_bg_color black
 tide_context_color_default yellow
 tide_context_color_root bryellow
 tide_context_color_ssh yellow
-tide_crystal_bg_color white
-tide_crystal_color black
+tide_crystal_bg_color black
+tide_crystal_color brwhite
 tide_docker_bg_color black
 tide_docker_color blue
 tide_git_bg_color black

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -10,6 +10,8 @@ tide_context_bg_color black
 tide_context_color_default yellow
 tide_context_color_root bryellow
 tide_context_color_ssh yellow
+tide_crystal_bg_color white
+tide_crystal_color black
 tide_docker_bg_color black
 tide_docker_color blue
 tide_git_bg_color black

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -20,8 +20,8 @@ tide_context_bg_color normal
 tide_context_color_default D7AF87
 tide_context_color_root $_tide_color_gold
 tide_context_color_ssh D7AF87
-tide_crystal_bg_color FFFFFF
-tide_crystal_color 000000
+tide_crystal_bg_color normal
+tide_crystal_color FFFFFF
 tide_crystal_icon ⬢
 tide_docker_bg_color normal
 tide_docker_color 2496ED
@@ -88,7 +88,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable 
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled false
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php chruby go kubectl toolbox terraform aws nix_shell
+tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php chruby go kubectl toolbox terraform aws nix_shell crystal
 tide_right_prompt_prefix ' '
 tide_right_prompt_separator_diff_color ' '
 tide_right_prompt_separator_same_color ' '

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -20,6 +20,9 @@ tide_context_bg_color normal
 tide_context_color_default D7AF87
 tide_context_color_root $_tide_color_gold
 tide_context_color_ssh D7AF87
+tide_crystal_bg_color FFFFFF
+tide_crystal_color 000000
+tide_crystal_icon ⬢
 tide_docker_bg_color normal
 tide_docker_color 2496ED
 tide_docker_default_contexts default colima

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -10,6 +10,8 @@ tide_context_bg_color normal
 tide_context_color_default yellow
 tide_context_color_root bryellow
 tide_context_color_ssh yellow
+tide_crystal_bg_color white
+tide_crystal_color black
 tide_docker_bg_color normal
 tide_docker_color blue
 tide_git_bg_color normal

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -10,8 +10,8 @@ tide_context_bg_color normal
 tide_context_color_default yellow
 tide_context_color_root bryellow
 tide_context_color_ssh yellow
-tide_crystal_bg_color white
-tide_crystal_color black
+tide_crystal_bg_color normal
+tide_crystal_color brwhite
 tide_docker_bg_color normal
 tide_docker_color blue
 tide_git_bg_color normal

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -88,7 +88,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable 
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php chruby go kubectl toolbox terraform aws nix_shell
+tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php chruby go kubectl toolbox terraform aws nix_shell crystal
 tide_right_prompt_prefix 
 tide_right_prompt_separator_diff_color 
 tide_right_prompt_separator_same_color 

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -20,6 +20,9 @@ tide_context_bg_color 444444
 tide_context_color_default D7AF87
 tide_context_color_root $_tide_color_gold
 tide_context_color_ssh D7AF87
+tide_crystal_bg_color FFFFFF
+tide_crystal_color 000000
+tide_crystal_icon ⬢
 tide_docker_bg_color 2496ED
 tide_docker_color 000000
 tide_docker_default_contexts default colima

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -10,6 +10,8 @@ tide_context_bg_color brblack
 tide_context_color_default yellow
 tide_context_color_root yellow
 tide_context_color_ssh yellow
+tide_crystal_bg_color white
+tide_crystal_color black
 tide_docker_bg_color blue
 tide_docker_color black
 tide_git_bg_color green

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -10,7 +10,7 @@ tide_context_bg_color brblack
 tide_context_color_default yellow
 tide_context_color_root yellow
 tide_context_color_ssh yellow
-tide_crystal_bg_color white
+tide_crystal_bg_color brwhite
 tide_crystal_color black
 tide_docker_bg_color blue
 tide_docker_color black

--- a/tests/_tide_item_crystal.test.fish
+++ b/tests/_tide_item_crystal.test.fish
@@ -1,0 +1,23 @@
+# RUN: %fish %s
+
+function _crystal
+    _tide_decolor (_tide_item_crystal)
+end
+
+set -l crystal_directory (mktemp -d)
+cd $crystal_directory
+
+mock crystal --version "echo 'Crystal 1.5.0 (2022-07-06)
+
+LLVM: 14.0.6
+Default target: aarch64-apple-darwin21.5.0'"
+
+set -lx tide_crystal_icon ⬢
+
+_crystal # CHECK:
+
+touch shard.yml
+
+_crystal # CHECK: ⬢ 1.5.0
+
+rm -r $crystal_directory


### PR DESCRIPTION
#### Description

Add a new prompt section (Tide Item) for the Crystal programming language (via a test exist check for a _shard.yml_ file).

#### Motivation and Context

Motivation you ask, well Crystal is awesome and so is Tide, and as such, Tide should also support version prompts for Crystal projects.

#### Screenshots (if appropriate)

I would include screenshots, but am having trouble testing live on my Mac and my Fish shell (despite that make tests pass)

#### How Has This Been Tested

- [ ] I have tested using **Linux**.
- [x] I have tested using **MacOS**.

<img width="1090" alt="Screen Shot 2022-08-04 at 4 08 27 PM" src="https://user-images.githubusercontent.com/1561054/182943150-935bf998-d426-4848-af1d-ab4202d49cb9.png">


#### Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
