### PR TITLE
Added option to show just user in the context

### DIFF
--- a/functions/_tide_item_context.fish
+++ b/functions/_tide_item_context.fish
@@ -4,6 +4,10 @@ function _tide_item_context
     else if test "$EUID" = 0
         tide_context_color=$tide_context_color_root _tide_print_item context $USER@$hostname
     else if test "$tide_context_always_display" = true
-        tide_context_color=$tide_context_color_default _tide_print_item context $USER@$hostname
+        if test "$tide_context_always_display_host" = true
+            tide_context_color=$tide_context_color_default _tide_print_item context $USER@$hostname
+        else
+            tide_context_color=$tide_context_color_default _tide_print_item context $USER
+        end
     end
 end

--- a/functions/_tide_item_context.fish
+++ b/functions/_tide_item_context.fish
@@ -4,10 +4,10 @@ function _tide_item_context
     else if test "$EUID" = 0
         tide_context_color=$tide_context_color_root _tide_print_item context $USER@$hostname
     else if test "$tide_context_always_display" = true
-        if test "$tide_context_always_display_host" = true
-            tide_context_color=$tide_context_color_default _tide_print_item context $USER@$hostname
-        else
+        if test "$tide_context_show_only_user" = true
             tide_context_color=$tide_context_color_default _tide_print_item context $USER
+        else
+            tide_context_color=$tide_context_color_default _tide_print_item context $USER@$hostname
         end
     end
 end

--- a/functions/tide.fish
+++ b/functions/tide.fish
@@ -2,7 +2,7 @@ function tide --description 'Manage your Tide prompt'
     argparse --stop-nonopt v/version h/help -- $argv
 
     if set -q _flag_version
-        echo 'tide, version 5.4.0'
+        echo 'tide, version 5.4.1'
     else if set -q _flag_help
         _tide_help
     else if functions --query _tide_sub_$argv[1]


### PR DESCRIPTION
#### Description

 you can now set `tide_context_always_display_host` to control if context will print `user@hostname` or just `user`. The print function still depends on `tide_context_always_display`

#### Motivation and Context

 I use tide in my work computer, that has a really ugly hostname that I cannot change, I still want to know with which user I'm logged into the terminal.

#### Screenshots (if appropriate)

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [X] I have tested using **Linux**.
- [X] I have tested using **MacOS**.

#### Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

I'm not sure how to test this, since the current test just validates `.*@.*` testing `.*` will always test true 