### PR TITLE
Fix prompt when `$PATH` contains a space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+- Prompt disappears entirely when `$PATH` contains a space (#329)
+
 ## [v5.4.0][] (Jul 29 2022)
 
 ### Features

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -37,8 +37,8 @@ if contains newline $_tide_left_items # two line prompt initialization
 function fish_prompt
     _tide_status=\$status _tide_pipestatus=\$pipestatus if not set -e _tide_repaint
         jobs -q && set -lx _tide_jobs
-        $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
-PATH=\$PATH CMD_DURATION=\$CMD_DURATION fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_2_line_prompt)\" &
+        $fish_path -c \"set _tide_pipestatus \$(string escape \"\$_tide_pipestatus\")
+PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$(string escape \"\$CMD_DURATION\") fish_bind_mode=\$(string escape \"\$fish_bind_mode\") set $(string escape $prompt_var) (_tide_2_line_prompt)\" &
         builtin disown
 
         command kill \$_tide_last_pid 2>/dev/null
@@ -65,8 +65,8 @@ else # one line prompt initialization
 function fish_prompt
     _tide_status=\$status _tide_pipestatus=\$pipestatus if not set -e _tide_repaint
         jobs -q && set -lx _tide_jobs
-        $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
-PATH=\$PATH CMD_DURATION=\$CMD_DURATION fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_1_line_prompt)\" &
+        $fish_path -c \"set _tide_pipestatus \$(string escape \"$_tide_pipestatus\")
+PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$(string escape \"\$CMD_DURATION\") fish_bind_mode=\$(string escape \"$fish_bind_mode\") set $(string escape $prompt_var) (_tide_1_line_prompt)\" &
         builtin disown
 
         command kill \$_tide_last_pid 2>/dev/null
@@ -83,5 +83,5 @@ end"
 end
 
 eval "function _tide_on_fish_exit --on-event fish_exit
-    set -e $prompt_var
+    set -e $(string escape $prompt_var)
 end"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

Recently, a directory containing a space got added to my `$PATH` variable. This breaks the `tide` prompt! The issue stems from incorrectly constructed `eval` strings; it's very difficult to get the quoting right, and hard to notice until you have a 'weird' character in a variable. Anyways, this patch fixes at least a few of these bugs.

#### Description

Fixes several bugs due to unsanitized `eval` inputs.

#### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Closes #329 

#### How Has This Been Tested

- [ ] I have tested using **Linux**.
- [x] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
