### PR TITLE
Update to `rm` command in tests

### DIFF
--- a/tests/_tide_item_crystal.test.fish
+++ b/tests/_tide_item_crystal.test.fish
@@ -20,4 +20,4 @@ touch shard.yml
 
 _crystal # CHECK: ⬢ 1.5.0
 
-rm -r $crystal_directory
+/bin/rm -r $crystal_directory

--- a/tests/_tide_item_crystal.test.fish
+++ b/tests/_tide_item_crystal.test.fish
@@ -20,4 +20,4 @@ touch shard.yml
 
 _crystal # CHECK: ⬢ 1.5.0
 
-/bin/rm -r $crystal_directory
+command rm -r $crystal_directory

--- a/tests/_tide_item_git.test.fish
+++ b/tests/_tide_item_git.test.fish
@@ -91,4 +91,4 @@ cd normal-repo
 _git_item # CHECK: 10charhere ?1
 
 # ------ cleanup ------
-rm -r $dir
+/bin/rm -r $dir

--- a/tests/_tide_item_git.test.fish
+++ b/tests/_tide_item_git.test.fish
@@ -91,4 +91,4 @@ cd normal-repo
 _git_item # CHECK: 10charhere ?1
 
 # ------ cleanup ------
-/bin/rm -r $dir
+command rm -r $dir

--- a/tests/_tide_item_go.test.fish
+++ b/tests/_tide_item_go.test.fish
@@ -15,4 +15,4 @@ _go # CHECK:
 touch go.mod
 _go # CHECK:  1.16.5
 
-rm -r $goDir
+/bin/rm -r $goDir

--- a/tests/_tide_item_go.test.fish
+++ b/tests/_tide_item_go.test.fish
@@ -15,4 +15,4 @@ _go # CHECK:
 touch go.mod
 _go # CHECK:  1.16.5
 
-/bin/rm -r $goDir
+command rm -r $goDir

--- a/tests/_tide_item_java.test.fish
+++ b/tests/_tide_item_java.test.fish
@@ -25,4 +25,4 @@ OpenJDK 64-Bit Server VM (build 25.332-b04, mixed mode)' >&2"
 
 _java # CHECK:  1.8.0
 
-rm -r $javaDir
+/bin/rm -r $javaDir

--- a/tests/_tide_item_java.test.fish
+++ b/tests/_tide_item_java.test.fish
@@ -25,4 +25,4 @@ OpenJDK 64-Bit Server VM (build 25.332-b04, mixed mode)' >&2"
 
 _java # CHECK:  1.8.0
 
-/bin/rm -r $javaDir
+command rm -r $javaDir

--- a/tests/_tide_item_node.test.fish
+++ b/tests/_tide_item_node.test.fish
@@ -15,4 +15,4 @@ _node # CHECK:
 touch package.json
 _node # CHECK: ⬢ 16.5.0
 
-rm -r $tmpdir
+/bin/rm -r $tmpdir

--- a/tests/_tide_item_node.test.fish
+++ b/tests/_tide_item_node.test.fish
@@ -15,4 +15,4 @@ _node # CHECK:
 touch package.json
 _node # CHECK: ⬢ 16.5.0
 
-/bin/rm -r $tmpdir
+command rm -r $tmpdir

--- a/tests/_tide_item_php.test.fish
+++ b/tests/_tide_item_php.test.fish
@@ -17,4 +17,4 @@ _php # CHECK:
 touch composer.json
 _php # CHECK:  8.0.2
 
-rm -r $phpDir
+/bin/rm -r $phpDir

--- a/tests/_tide_item_php.test.fish
+++ b/tests/_tide_item_php.test.fish
@@ -17,4 +17,4 @@ _php # CHECK:
 touch composer.json
 _php # CHECK:  8.0.2
 
-/bin/rm -r $phpDir
+command rm -r $phpDir

--- a/tests/_tide_item_pwd.test.fish
+++ b/tests/_tide_item_pwd.test.fish
@@ -28,15 +28,15 @@ _pwd /tmp/$longDir # CHECK: normal_icon /t/a/b/c/d/e/f/g/h/india/juliett/kilo/li
 
 mkdir -p /tmp/alfa/bratwurst
 _pwd /tmp/$longDir # CHECK: normal_icon /t/a/brav/c/d/e/f/g/h/i/juliett/kilo/lima/mike/november/oscar/papa
-/bin/rm -r /tmp/alfa/bratwurst
+command rm -r /tmp/alfa/bratwurst
 
 mkdir -p /tmp/alfa/bravohello
 _pwd /tmp/$longDir # CHECK: normal_icon /t/a/bravo/c/d/e/f/g/h/i/juliett/kilo/lima/mike/november/oscar/papa
-/bin/rm -r /tmp/alfa/bravohello
+command rm -r /tmp/alfa/bravohello
 
 mkdir -p /tmp/.git
 _pwd /tmp/$longDir # CHECK: normal_icon /tmp/a/b/c/d/e/f/g/h/i/juliett/kilo/lima/mike/november/oscar/papa
-/bin/rm -r /tmp/.git
+command rm -r /tmp/.git
 
 # ------------------Starts with home------------------
 _pwd $tmpdir/ # CHECK: home_icon ~
@@ -48,15 +48,15 @@ _pwd $tmpdir/tmp/$longDir # CHECK: normal_icon ~/t/a/b/c/d/e/f/g/h/india/juliett
 
 mkdir -p $tmpdir/tmp/alfa/bratwurst
 _pwd $tmpdir/tmp/$longDir # CHECK: normal_icon ~/t/a/brav/c/d/e/f/g/h/i/juliett/kilo/lima/mike/november/oscar/papa
-/bin/rm -r $tmpdir/tmp/alfa/bratwurst
+command rm -r $tmpdir/tmp/alfa/bratwurst
 
 mkdir -p $tmpdir/tmp/alfa/bravohello
 _pwd $tmpdir/tmp/$longDir # CHECK: normal_icon ~/t/a/bravo/c/d/e/f/g/h/i/juliett/kilo/lima/mike/november/oscar/papa
-/bin/rm -r $tmpdir/tmp/alfa/bravohello
+command rm -r $tmpdir/tmp/alfa/bravohello
 
 mkdir -p $tmpdir/tmp/.git
 _pwd $tmpdir/tmp/$longDir # CHECK: normal_icon ~/tmp/a/b/c/d/e/f/g/h/i/juliett/kilo/lima/mike/november/oscar/papa
-/bin/rm -r $tmpdir/tmp/.git
+command rm -r $tmpdir/tmp/.git
 
 # ------------------------------------NO ICONS-----------------------------------
 set -lx tide_pwd_icon_unwritable
@@ -73,15 +73,15 @@ _pwd /tmp/$longDir # CHECK: /t/a/b/c/d/e/foxtrot/golf/hotel/india/juliett/kilo/l
 
 mkdir -p /tmp/alfa/bratwurst
 _pwd /tmp/$longDir # CHECK: /t/a/brav/c/d/e/f/golf/hotel/india/juliett/kilo/lima/mike/november/oscar/papa
-/bin/rm -r /tmp/alfa/bratwurst
+command rm -r /tmp/alfa/bratwurst
 
 mkdir -p /tmp/alfa/bravohello
 _pwd /tmp/$longDir # CHECK: /t/a/bravo/c/d/e/f/golf/hotel/india/juliett/kilo/lima/mike/november/oscar/papa
-/bin/rm -r /tmp/alfa/bravohello
+command rm -r /tmp/alfa/bravohello
 
 mkdir -p /tmp/.git
 _pwd /tmp/$longDir # CHECK: /tmp/a/b/c/d/e/f/golf/hotel/india/juliett/kilo/lima/mike/november/oscar/papa
-/bin/rm -r /tmp/.git
+command rm -r /tmp/.git
 
 # ------------------Starts with home------------------
 _pwd $tmpdir/ # CHECK: ~
@@ -93,15 +93,15 @@ _pwd $tmpdir/tmp/$longDir # CHECK: ~/t/a/b/c/d/e/f/golf/hotel/india/juliett/kilo
 
 mkdir -p $tmpdir/tmp/alfa/bratwurst
 _pwd $tmpdir/tmp/$longDir # CHECK: ~/t/a/brav/c/d/e/f/golf/hotel/india/juliett/kilo/lima/mike/november/oscar/papa
-/bin/rm -r $tmpdir/tmp/alfa/bratwurst
+command rm -r $tmpdir/tmp/alfa/bratwurst
 
 mkdir -p $tmpdir/tmp/alfa/bravohello
 _pwd $tmpdir/tmp/$longDir # CHECK: ~/t/a/bravo/c/d/e/f/golf/hotel/india/juliett/kilo/lima/mike/november/oscar/papa
-/bin/rm -r $tmpdir/tmp/alfa/bravohello
+command rm -r $tmpdir/tmp/alfa/bravohello
 
 mkdir -p $tmpdir/tmp/.git
 _pwd $tmpdir/tmp/$longDir # CHECK: ~/tmp/a/b/c/d/e/f/golf/hotel/india/juliett/kilo/lima/mike/november/oscar/papa
-/bin/rm -r $tmpdir/tmp/.git
+command rm -r $tmpdir/tmp/.git
 
 # ------------------------------------Cleanup------------------------------------
-/bin/rm -r $tmpdir
+command rm -r $tmpdir

--- a/tests/_tide_item_pwd.test.fish
+++ b/tests/_tide_item_pwd.test.fish
@@ -28,15 +28,15 @@ _pwd /tmp/$longDir # CHECK: normal_icon /t/a/b/c/d/e/f/g/h/india/juliett/kilo/li
 
 mkdir -p /tmp/alfa/bratwurst
 _pwd /tmp/$longDir # CHECK: normal_icon /t/a/brav/c/d/e/f/g/h/i/juliett/kilo/lima/mike/november/oscar/papa
-rm -r /tmp/alfa/bratwurst
+/bin/rm -r /tmp/alfa/bratwurst
 
 mkdir -p /tmp/alfa/bravohello
 _pwd /tmp/$longDir # CHECK: normal_icon /t/a/bravo/c/d/e/f/g/h/i/juliett/kilo/lima/mike/november/oscar/papa
-rm -r /tmp/alfa/bravohello
+/bin/rm -r /tmp/alfa/bravohello
 
 mkdir -p /tmp/.git
 _pwd /tmp/$longDir # CHECK: normal_icon /tmp/a/b/c/d/e/f/g/h/i/juliett/kilo/lima/mike/november/oscar/papa
-rm -r /tmp/.git
+/bin/rm -r /tmp/.git
 
 # ------------------Starts with home------------------
 _pwd $tmpdir/ # CHECK: home_icon ~
@@ -48,15 +48,15 @@ _pwd $tmpdir/tmp/$longDir # CHECK: normal_icon ~/t/a/b/c/d/e/f/g/h/india/juliett
 
 mkdir -p $tmpdir/tmp/alfa/bratwurst
 _pwd $tmpdir/tmp/$longDir # CHECK: normal_icon ~/t/a/brav/c/d/e/f/g/h/i/juliett/kilo/lima/mike/november/oscar/papa
-rm -r $tmpdir/tmp/alfa/bratwurst
+/bin/rm -r $tmpdir/tmp/alfa/bratwurst
 
 mkdir -p $tmpdir/tmp/alfa/bravohello
 _pwd $tmpdir/tmp/$longDir # CHECK: normal_icon ~/t/a/bravo/c/d/e/f/g/h/i/juliett/kilo/lima/mike/november/oscar/papa
-rm -r $tmpdir/tmp/alfa/bravohello
+/bin/rm -r $tmpdir/tmp/alfa/bravohello
 
 mkdir -p $tmpdir/tmp/.git
 _pwd $tmpdir/tmp/$longDir # CHECK: normal_icon ~/tmp/a/b/c/d/e/f/g/h/i/juliett/kilo/lima/mike/november/oscar/papa
-rm -r $tmpdir/tmp/.git
+/bin/rm -r $tmpdir/tmp/.git
 
 # ------------------------------------NO ICONS-----------------------------------
 set -lx tide_pwd_icon_unwritable
@@ -73,15 +73,15 @@ _pwd /tmp/$longDir # CHECK: /t/a/b/c/d/e/foxtrot/golf/hotel/india/juliett/kilo/l
 
 mkdir -p /tmp/alfa/bratwurst
 _pwd /tmp/$longDir # CHECK: /t/a/brav/c/d/e/f/golf/hotel/india/juliett/kilo/lima/mike/november/oscar/papa
-rm -r /tmp/alfa/bratwurst
+/bin/rm -r /tmp/alfa/bratwurst
 
 mkdir -p /tmp/alfa/bravohello
 _pwd /tmp/$longDir # CHECK: /t/a/bravo/c/d/e/f/golf/hotel/india/juliett/kilo/lima/mike/november/oscar/papa
-rm -r /tmp/alfa/bravohello
+/bin/rm -r /tmp/alfa/bravohello
 
 mkdir -p /tmp/.git
 _pwd /tmp/$longDir # CHECK: /tmp/a/b/c/d/e/f/golf/hotel/india/juliett/kilo/lima/mike/november/oscar/papa
-rm -r /tmp/.git
+/bin/rm -r /tmp/.git
 
 # ------------------Starts with home------------------
 _pwd $tmpdir/ # CHECK: ~
@@ -93,15 +93,15 @@ _pwd $tmpdir/tmp/$longDir # CHECK: ~/t/a/b/c/d/e/f/golf/hotel/india/juliett/kilo
 
 mkdir -p $tmpdir/tmp/alfa/bratwurst
 _pwd $tmpdir/tmp/$longDir # CHECK: ~/t/a/brav/c/d/e/f/golf/hotel/india/juliett/kilo/lima/mike/november/oscar/papa
-rm -r $tmpdir/tmp/alfa/bratwurst
+/bin/rm -r $tmpdir/tmp/alfa/bratwurst
 
 mkdir -p $tmpdir/tmp/alfa/bravohello
 _pwd $tmpdir/tmp/$longDir # CHECK: ~/t/a/bravo/c/d/e/f/golf/hotel/india/juliett/kilo/lima/mike/november/oscar/papa
-rm -r $tmpdir/tmp/alfa/bravohello
+/bin/rm -r $tmpdir/tmp/alfa/bravohello
 
 mkdir -p $tmpdir/tmp/.git
 _pwd $tmpdir/tmp/$longDir # CHECK: ~/tmp/a/b/c/d/e/f/golf/hotel/india/juliett/kilo/lima/mike/november/oscar/papa
-rm -r $tmpdir/tmp/.git
+/bin/rm -r $tmpdir/tmp/.git
 
 # ------------------------------------Cleanup------------------------------------
-rm -r $tmpdir
+/bin/rm -r $tmpdir

--- a/tests/_tide_item_rustc.test.fish
+++ b/tests/_tide_item_rustc.test.fish
@@ -15,4 +15,4 @@ _rustc # CHECK:
 touch Cargo.toml
 _rustc # CHECK:  1.30.0
 
-rm -r $rustcDir
+/bin/rm -r $rustcDir

--- a/tests/_tide_item_rustc.test.fish
+++ b/tests/_tide_item_rustc.test.fish
@@ -15,4 +15,4 @@ _rustc # CHECK:
 touch Cargo.toml
 _rustc # CHECK:  1.30.0
 
-/bin/rm -r $rustcDir
+command rm -r $rustcDir

--- a/tests/_tide_item_terraform.test.fish
+++ b/tests/_tide_item_terraform.test.fish
@@ -16,4 +16,4 @@ _terraform # CHECK:
 mock terraform "workspace show" "echo test"
 _terraform # CHECK: test
 
-/bin/rm -r $terraformDir
+command rm -r $terraformDir

--- a/tests/_tide_item_terraform.test.fish
+++ b/tests/_tide_item_terraform.test.fish
@@ -16,4 +16,4 @@ _terraform # CHECK:
 mock terraform "workspace show" "echo test"
 _terraform # CHECK: test
 
-rm -r $terraformDir
+/bin/rm -r $terraformDir

--- a/tests/_tide_item_time.test.fish
+++ b/tests/_tide_item_time.test.fish
@@ -11,4 +11,4 @@ _time '' # CHECK:
 _time %T # CHECK: {{\d\d:\d\d:\d\d}}
 
 # 12 Hour
-_time %r # CHECK: {{\d\d:\d\d:\d\d (A|P)M [A-Z][A-Z][A-Z]}}
+_time %r # CHECK: {{\d\d:\d\d:\d\d (A|P)M}}

--- a/tests/_tide_item_time.test.fish
+++ b/tests/_tide_item_time.test.fish
@@ -11,4 +11,4 @@ _time '' # CHECK:
 _time %T # CHECK: {{\d\d:\d\d:\d\d}}
 
 # 12 Hour
-_time %r # CHECK: {{\d\d:\d\d:\d\d (A|P)M}}
+_time %r # CHECK: {{\d\d:\d\d:\d\d (A|P)M [A-Z][A-Z][A-Z]}}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Description/Motivation/Context/~Text Dump :P~

I was facing a common issue across multiple tests when I first tried to run `make test` in this repo. And being very new to the testing framework it took me quite a while to figure out what's wrong.

Basically I had my `rm` aliased (and forgotten about :) ) to `rm -v` which caused verbose output to stdout which then resulted as a failed case as the tests weren't expecting any extra lines of output. A simple change of all `rm`'s to `/bin/rm` fixed this for me.

IMO this type of change will bring about predictability and remove possible side effects (due to local aliases) with the test cases, which should be the case with test cases, as test cases should not be environment dependent. This could probably be extended to other core commands that are used in these tests as well.

Thoughts ?

#### How Has This Been Tested

Running `make test`
<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.