### PR TITLE
Use prompt_hostname for obtaining hostname

### DIFF
--- a/functions/_tide_item_context.fish
+++ b/functions/_tide_item_context.fish
@@ -1,9 +1,9 @@
 function _tide_item_context
     if set -q SSH_TTY
-        tide_context_color=$tide_context_color_ssh _tide_print_item context $USER@$hostname
+        tide_context_color=$tide_context_color_ssh _tide_print_item context "$USER@$(prompt_hostname)"
     else if test "$EUID" = 0
-        tide_context_color=$tide_context_color_root _tide_print_item context $USER@$hostname
+        tide_context_color=$tide_context_color_root _tide_print_item context "$USER@$(prompt_hostname)"
     else if test "$tide_context_always_display" = true
-        tide_context_color=$tide_context_color_default _tide_print_item context $USER@$hostname
+        tide_context_color=$tide_context_color_default _tide_print_item context "$USER@$(prompt_hostname)"
     end
 end


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Description
`prompt_hostname` is a function from fish-shell ([src](https://github.com/fish-shell/fish-shell/blob/master/share/functions/prompt_hostname.fish)). It is rather simple but useful when hostname is very long.

I have not tested this change.