### PR TITLE
Display toolbox name

### DIFF
--- a/functions/_tide_item_toolbox.fish
+++ b/functions/_tide_item_toolbox.fish
@@ -1,3 +1,4 @@
 function _tide_item_toolbox
-    test -e /run/.toolboxenv && _tide_print_item toolbox $tide_toolbox_icon' ' $(cat /run/.containerenv | sed -n '2 p' | awk -F '"' 'NF>2{print $2}')
+    test -e /run/.toolboxenv &&
+        _tide_print_item toolbox $tide_toolbox_icon' ' (string match -rg 'name="(.*)"' </run/.containerenv)
 end

--- a/functions/_tide_item_toolbox.fish
+++ b/functions/_tide_item_toolbox.fish
@@ -1,3 +1,3 @@
 function _tide_item_toolbox
-    test -e /run/.toolboxenv && _tide_print_item toolbox $tide_toolbox_icon' ' $hostname
+    test -e /run/.toolboxenv && _tide_print_item toolbox $tide_toolbox_icon' ' $(cat /run/.containerenv | sed -n '2 p' | awk -F '"' 'NF>2{print $2}')
 end


### PR DESCRIPTION
#### Description

Displays the toolbox name instead of the word toolbox.

#### Motivation and Context
$hostname defaults to "toolbox" when inside a toolbox.
$tide_toolbox_icon already indicates we're in a toolbox. 
Displaying the toolbox name adds further context in multi-toolbox environments.

#### Screenshots (if appropriate)

#### How Has This Been Tested

I tested this on Fedora Silverblue 36

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

Unsure if these are applicable.

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
