### PR TITLE
add proxy item

### DIFF
--- a/functions/_tide_item_proxy.fish
+++ b/functions/_tide_item_proxy.fish
@@ -1,0 +1,5 @@
+function _tide_item_proxy
+    begin
+        env | grep -i -q 'all_proxy=\|http_proxy=\|https_proxy='
+    end && _tide_print_item proxy $tide_proxy_icon
+end

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -89,7 +89,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable 
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php chruby go kubectl toolbox terraform aws nix_shell crystal
+tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php chruby go kubectl toolbox terraform aws nix_shell crystal proxy
 tide_right_prompt_prefix 
 tide_right_prompt_separator_diff_color 
 tide_right_prompt_separator_same_color 
@@ -131,3 +131,6 @@ tide_vi_mode_icon_visual V
 tide_virtual_env_bg_color 444444
 tide_virtual_env_color 00AFAF
 tide_virtual_env_icon 
+tide_proxy_bg_color 444444
+tide_proxy_color FFBF00
+tide_proxy_icon 䀹

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -63,6 +63,8 @@ tide_time_bg_color black
 tide_time_color brblack
 tide_toolbox_bg_color black
 tide_toolbox_color magenta
+tide_proxy_bg_color black
+tide_toolbox_color yellow
 tide_vi_mode_bg_color_default black
 tide_vi_mode_bg_color_insert black
 tide_vi_mode_bg_color_replace black

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -89,7 +89,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable 
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled false
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php chruby go kubectl toolbox terraform aws nix_shell crystal
+tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php chruby go kubectl toolbox terraform aws nix_shell crystal proxy
 tide_right_prompt_prefix ' '
 tide_right_prompt_separator_diff_color ' '
 tide_right_prompt_separator_same_color ' '
@@ -131,3 +131,6 @@ tide_vi_mode_icon_visual V
 tide_virtual_env_bg_color normal
 tide_virtual_env_color 00AFAF
 tide_virtual_env_icon 
+tide_proxy_bg_color normal
+tide_proxy_color FFBF00
+tide_proxy_icon 䀹

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -63,6 +63,8 @@ tide_time_bg_color normal
 tide_time_color brblack
 tide_toolbox_bg_color normal
 tide_toolbox_color magenta
+tide_proxy_bg_color normal
+tide_proxy_color yellow
 tide_vi_mode_bg_color_default normal
 tide_vi_mode_bg_color_insert normal
 tide_vi_mode_bg_color_replace normal

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -89,7 +89,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable 
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php chruby go kubectl toolbox terraform aws nix_shell crystal
+tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php chruby go kubectl toolbox terraform aws nix_shell crystal proxy
 tide_right_prompt_prefix 
 tide_right_prompt_separator_diff_color 
 tide_right_prompt_separator_same_color 
@@ -131,3 +131,6 @@ tide_vi_mode_icon_visual V
 tide_virtual_env_bg_color 444444
 tide_virtual_env_color 00AFAF
 tide_virtual_env_icon 
+tide_proxy_bg_color 444444
+tide_proxy_color FFBF00
+tide_proxy_icon 䀹

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -63,6 +63,8 @@ tide_time_bg_color white
 tide_time_color black
 tide_toolbox_bg_color magenta
 tide_toolbox_color black
+tide_proxy_bg_color yellow
+tide_proxy_color black
 tide_vi_mode_bg_color_default white
 tide_vi_mode_bg_color_insert cyan
 tide_vi_mode_bg_color_replace green

--- a/tests/_tide_item_proxy.test.fish
+++ b/tests/_tide_item_proxy.test.fish
@@ -1,0 +1,14 @@
+# RUN: %fish %s
+_tide_parent_dirs
+
+set -lx tide_proxy_icon 䀹
+
+set -lx HTTP_PROXY http://127.0.0.1:7890
+_tide_decolor (_tide_item_proxy) # CHECK: 䀹
+set -e HTTP_PROXY
+
+set -lx all_proxy http://127.0.0.1:7890
+_tide_decolor (_tide_item_proxy) # CHECK: 䀹
+set -e all_proxy
+
+_tide_decolor (_tide_item_jobs) # CHECK:


### PR DESCRIPTION
This PR adds the prompt item proxy, which checks and displays if any `_PROXY` env has been set.


#### Description
display an icon if any of `http_proxy` `all_proxy` `https_proxy` is presented (ignore case)


#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/282373/190092174-3d49d8dc-9b96-4bb5-87c6-d01931821b6b.png)


#### How Has This Been Tested


- [x] I have tested using **Linux**.
- [x] I have tested using **MacOS**.

#### Checklist

- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
