### PR TITLE
Fix distrobox prompt support

### DIFF
--- a/functions/_tide_item_distrobox.fish
+++ b/functions/_tide_item_distrobox.fish
@@ -1,4 +1,4 @@
 function _tide_item_distrobox
-    command -q distrobox-enter || # distrobox-enter is not present in the container
+    test -e /etc/profile.d/distrobox_profile.sh && test -e /run/.containerenv &&                          # distrobox-enter is not present in the container
         _tide_print_item distrobox $tide_distrobox_icon' ' (string match -rg 'name="(.*)"' </run/.containerenv)
 end

--- a/functions/_tide_item_distrobox.fish
+++ b/functions/_tide_item_distrobox.fish
@@ -1,4 +1,7 @@
 function _tide_item_distrobox
-    test -e /run/.distroboxenv &&
-        _tide_print_item distrobox $tide_distrobox_icon' ' (string match -rg 'name="(.*)"' </run/.containerenv)
+    if not command -v distrobox-enter >/dev/null
+        if command -v distrobox-export >/dev/null
+            _tide_print_item distrobox $tide_distrobox_icon' ' (string match -rg 'name="(.*)"' </run/.containerenv)
+		end
+	end
 end

--- a/functions/_tide_item_distrobox.fish
+++ b/functions/_tide_item_distrobox.fish
@@ -1,4 +1,4 @@
 function _tide_item_distrobox
-    test -e /etc/profile.d/distrobox_profile.sh && test -e /run/.containerenv &&                          # distrobox-enter is not present in the container
+    test -e /etc/profile.d/distrobox_profile.sh && test -e /run/.containerenv &&
         _tide_print_item distrobox $tide_distrobox_icon' ' (string match -rg 'name="(.*)"' </run/.containerenv)
 end

--- a/functions/_tide_item_distrobox.fish
+++ b/functions/_tide_item_distrobox.fish
@@ -1,7 +1,4 @@
 function _tide_item_distrobox
-    if not command -v distrobox-enter >/dev/null
-        if command -v distrobox-export >/dev/null
-            _tide_print_item distrobox $tide_distrobox_icon' ' (string match -rg 'name="(.*)"' </run/.containerenv)
-		end
-	end
+    command -q distrobox-enter || # distrobox-enter is not present in the container
+        _tide_print_item distrobox $tide_distrobox_icon' ' (string match -rg 'name="(.*)"' </run/.containerenv)
 end

--- a/functions/_tide_remove_unusable_items.fish
+++ b/functions/_tide_remove_unusable_items.fish
@@ -5,7 +5,7 @@ function _tide_remove_unusable_items
         set -l cli_names $item
         switch $item
             case distrobox                           # there is no '/usr/bin/distrobox' inside the container. 'distrobox-export' and 'distrobox-host-exec' are found. 
-                set cli_names distrobox-export       # It would be more accurate to check the existence of these two files.
+                set cli_names distrobox-export       # It would be more accurate to check the existence of these two files. See: https://github.com/IlanCosman/tide/pull/351
             case virtual_env
                 set cli_names python python3
             case nix_shell

--- a/functions/_tide_remove_unusable_items.fish
+++ b/functions/_tide_remove_unusable_items.fish
@@ -4,8 +4,8 @@ function _tide_remove_unusable_items
     for item in aws chruby crystal distrobox docker git go java kubectl nix_shell node php pulumi rustc terraform toolbox virtual_env
         set -l cli_names $item
         switch $item
-            case distrobox                           # there is no '/usr/bin/distrobox' inside the container. 'distrobox-export' and 'distrobox-host-exec' are found. 
-                set cli_names distrobox-export       # It would be more accurate to check the existence of these two files. See: https://github.com/IlanCosman/tide/pull/351
+            case distrobox # there is no 'distrobox' command inside the container
+                set cli_names distrobox-export # 'distrobox-export' and 'distrobox-host-exec' are available
             case virtual_env
                 set cli_names python python3
             case nix_shell

--- a/functions/_tide_remove_unusable_items.fish
+++ b/functions/_tide_remove_unusable_items.fish
@@ -4,6 +4,8 @@ function _tide_remove_unusable_items
     for item in aws chruby crystal distrobox docker git go java kubectl nix_shell node php pulumi rustc terraform toolbox virtual_env
         set -l cli_names $item
         switch $item
+            case distrobox                           # there is no '/usr/bin/distrobox' inside the container. 'distrobox-export' and 'distrobox-host-exec' are found. 
+                set cli_names distrobox-export       # It would be more accurate to check the existence of these two files.
             case virtual_env
                 set cli_names python python3
             case nix_shell

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -95,7 +95,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable 
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php pulumi chruby go kubectl toolbox terraform aws nix_shell crystal
+tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php pulumi chruby go kubectl distrobox toolbox terraform aws nix_shell crystal
 tide_right_prompt_prefix 
 tide_right_prompt_separator_diff_color 
 tide_right_prompt_separator_same_color 

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -95,7 +95,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable 
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled false
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php pulumi chruby go kubectl toolbox terraform aws nix_shell crystal
+tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php pulumi chruby go kubectl distrobox toolbox terraform aws nix_shell crystal
 tide_right_prompt_prefix ' '
 tide_right_prompt_separator_diff_color ' '
 tide_right_prompt_separator_same_color ' '

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -95,7 +95,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable 
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php pulumi chruby go kubectl toolbox terraform aws nix_shell crystal
+tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php pulumi chruby go kubectl distrobox toolbox terraform aws nix_shell crystal
 tide_right_prompt_prefix 
 tide_right_prompt_separator_diff_color 
 tide_right_prompt_separator_same_color 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Fix distrobox prompt support
I recently installed distrobox. But I couldn't see a prompt that I'm in distrobox (like toolbox). I reviewed this page today. I recently saw that distrobox prompt support has been added #332. But it wasn't working for me. When I examined the codes, I noticed that there were deficiencies.
- /run/.distroboxenv file not found inside distrobox containers
- /usr/bin/distrobox file not found inside distrobox containers

<!-- Describe your changes. -->
Fixed this problem(s)

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Closes #332

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/62564400/192964632-f54a4783-f23a-4a59-9c1a-cb923d794a4d.png)

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.
