### PR TITLE
Add Void Linux icon

### DIFF
--- a/functions/_tide_detect_os.fish
+++ b/functions/_tide_detect_os.fish
@@ -69,6 +69,8 @@ function _tide_detect_os_linux_cases -a file key
             printf %s\n  $defaultColor # Doesn't really have a logo, and the colors are too close to PWD blue anyway
         case ubuntu
             printf %s\n  E95420 D4D4D4 # https://design.ubuntu.com/brand/
+        case void
+            printf %s\n  FFFFFF 478061 # from https://alpha.de.repo.voidlinux.org/logos/void.svg
         case '*'
             return 1
     end


### PR DESCRIPTION
#### Description

Show Void Linux icon `f32e` in place of the default Linux icon if Void Linux is detected