### PR TITLE
Add a note about git version

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 
 - The **latest** version of [Fish][], currently 3.5.1. <sub>[Using an older version of Fish?][]</sub>
 - A [Nerd Font][nerd fonts] installed and enabled in your terminal (for example the [recommended font](#fonts)).
+- A [Git][git], version >=2.22
 
 Install with [Fisher][]:
 
@@ -145,6 +146,7 @@ Open each file and click "Install". This will make the `MesloLGS NF` font availa
 [contributing guide]: CONTRIBUTING.md
 [fish]: https://fishshell.com/
 [fisher]: https://github.com/jorgebucaran/fisher
+[git]: https://git-scm.com
 [license_badge]: https://img.shields.io/github/license/IlanCosman/tide
 [license]: LICENSE.md
 [meslolgs nf bold italic.ttf]: ../assets/fonts/mesloLGS_NF_bold_italic.ttf?raw=true


### PR DESCRIPTION
Tide doesn't work with the git version less than 2.22

#### Description

Changed only the note in README file.

The reason why it doesn't work with lower git versions is because Tide uses `--show-current` option to determine the current branch, but that option was introduced in git v2.22

#### Motivation and Context

Notify the users about the requirements

#### Screenshots (if appropriate)

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [x] I have tested using **Linux**.
- [x] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.
