### PR TITLE
Added $tide_git_truncate_end to truncate the end of a git branch instead of the beginning

### DIFF
--- a/functions/_tide_item_git.fish
+++ b/functions/_tide_item_git.fish
@@ -1,10 +1,10 @@
 function _tide_item_git
     if set -q tide_git_truncate_end
-        set -l branch_truncation_regex "(.{$tide_git_truncation_length}).+"
-        set -l branch_truncation_replacement '$1…'
+        set -f branch_truncation_regex "(.{$tide_git_truncation_length}).+"
+        set -f branch_truncation_replacement '$1…'
     else
-        set -l branch_truncation_regex ".+(.{$tide_git_truncation_length})"
-        set -l branch_truncation_replacement '…$1'
+        set -f branch_truncation_regex ".+(.{$tide_git_truncation_length})"
+        set -f branch_truncation_replacement '…$1'
     end
 
     if git branch --show-current 2>/dev/null | string replace -r $branch_truncation_regex $branch_truncation_replacement | read -l location

--- a/functions/_tide_item_git.fish
+++ b/functions/_tide_item_git.fish
@@ -1,10 +1,18 @@
 function _tide_item_git
-    if git branch --show-current 2>/dev/null | string replace -r ".+(.{$tide_git_truncation_length})" '…$1' | read -l location
+    if set -q tide_git_truncate_end
+        set -l branch_truncation_regex "(.{$tide_git_truncation_length}).+"
+        set -l branch_truncation_replacement '$1…'
+    else
+        set -l branch_truncation_regex ".+(.{$tide_git_truncation_length})"
+        set -l branch_truncation_replacement '…$1'
+    end
+
+    if git branch --show-current 2>/dev/null | string replace -r $branch_truncation_regex $branch_truncation_replacement | read -l location
         git rev-parse --git-dir --is-inside-git-dir | read -fL gdir in_gdir
         set location $_tide_location_color$location
     else if test $pipestatus[1] != 0
         return
-    else if git tag --points-at HEAD | string replace -r ".+(.{$tide_git_truncation_length})" '…$1' | read location
+    else if git tag --points-at HEAD | string replace -r $branch_truncation_regex $branch_truncation_replacement | read location
         git rev-parse --git-dir --is-inside-git-dir | read -fL gdir in_gdir
         set location '#'$_tide_location_color$location
     else

--- a/tests/_tide_item_git.test.fish
+++ b/tests/_tide_item_git.test.fish
@@ -63,6 +63,10 @@ _git checkout -b very_long_branch_name
 set -lx tide_git_truncation_length 10
 _git_item # CHECK: …ranch_name
 
+# Branch truncates the end of the branch
+set -lx tide_git_truncate_end
+_git_item # CHECK: very_long_…
+
 # Branch same length as tide_git_truncation_length
 _git checkout -b 10charhere
 _git_item # CHECK: 10charhere


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Description

Depending if `$tide_git_truncate_end` is set, I set the regex matcher and the regex replacement for the branch truncation accordingly.
<!-- Describe your changes. -->

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
Closes #377  <!--- Please link to an open issue. -->

#### Screenshots (if appropriate)

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

I'm unsure how to test this.
The tests give me errors on lines I haven't changed.
I'm running `env HOME=/tmp/fishy3/ fish` from within the tide repo, to create a temporary new fish config, then run `make all` and I get the following:

```
Testing file tests/_tide_item_git.test.fish ... Failure:

  The CHECK on line 26 wants:
    main

  which failed to match line stdout:8:
     @44c1529

  additional output on stderr:1:24:
    string replace: expected >= 2 arguments; got 0
    string replace: expected >= 2 arguments; got 0
    string replace: expected >= 2 arguments; got 0
    string replace: expected >= 2 arguments; got 0
    string replace: expected >= 2 arguments; got 0
    string replace: expected >= 2 arguments; got 0
    string replace: expected >= 2 arguments; got 0
    string replace: expected >= 2 arguments; got 0
    string replace: expected >= 2 arguments; got 0
    string replace: expected >= 2 arguments; got 0
    string replace: expected >= 2 arguments; got 0
    string replace: expected >= 2 arguments; got 0
    string replace: expected >= 2 arguments; got 0
    string replace: expected >= 2 arguments; got 0
    cd: The directory 'normal-repo' does not exist
    /usr/share/fish/functions/cd.fish (Zeile 30): 
        builtin cd $argv
        ^
    in function 'cd' with arguments 'normal-repo'
        called on line 88 of file tests/_tide_item_git.test.fish
    string replace: expected >= 2 arguments; got 0
    string replace: expected >= 2 arguments; got 0
    string replace: expected >= 2 arguments; got 0
    string replace: expected >= 2 arguments; got 0

  Context:
     @44c1529 <= does not match CHECK on line 26: main
     <= nothing to match CHECK on line 30: main
     <= nothing to match CHECK on line 35: main ?1
     <= nothing to match CHECK on line 39: main +1
     <= nothing to match CHECK on line 47: main !1
     <= nothing to match CHECK on line 51: main *1

  when running command:
    fish tests/_tide_item_git.test.fish
Testing file tests/_tide_item_go.test.fish ... ok (16 ms)
Testing file tests/_tide_item_java.test.fish ... ok (16 ms)
Testing file tests/_tide_item_jobs.test.fish ... ok (14 ms)
Testing file tests/_tide_item_kubectl.test.fish ... ok (16 ms)
Testing file tests/_tide_item_nix_shell.test.fish ... ok (13 ms)
Testing file tests/_tide_item_node.test.fish ... ok (15 ms)
Testing file tests/_tide_item_php.test.fish ... ok (15 ms)
Testing file tests/_tide_item_pulumi.test.fish ... ok (18 ms)
Testing file tests/_tide_item_pwd.test.fish ... ok (98 ms)
Testing file tests/_tide_item_rustc.test.fish ... ok (16 ms)
Testing file tests/_tide_item_status.test.fish ... ok (20 ms)
Testing file tests/_tide_item_terraform.test.fish ... ok (16 ms)
Testing file tests/_tide_item_time.test.fish ... Failure:

  The CHECK on line 15 wants:
    {{\\d\\d:\\d\\d:\\d\\d (A|P)M}}

  which failed to match line stdout:3:
     11:29:06 

  Context:
     11:29:06
     11:29:06  <= does not match CHECK on line 15: {{\\d\\d:\\d\\d:\\d\\d (A|P)M}}

  when running command:
    fish tests/_tide_item_time.test.fish
Testing file tests/_tide_item_virtual_env.test.fish ... ok (13 ms)
Testing file tests/_tide_parent_dirs.test.fish ... ok (17 ms)
Testing file tests/detect_os/_tide_detect_os.test.fish ... ok (15 ms)
make: *** [Makefile:27: test] Fehler 1
```

- [ ] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I am ready to update the wiki accordingly.
  - will do if this get's merged
- [x] I have updated the tests accordingly.
