### PR TITLE
Detect msys2 as windows

### DIFF
--- a/functions/_tide_detect_os.fish
+++ b/functions/_tide_detect_os.fish
@@ -6,7 +6,7 @@ function _tide_detect_os
             printf %s\n  D6D6D6 333333 # from apple.com header
         case freebsd openbsd dragonfly
             printf %s\n  FFFFFF AB2B28 # https://freebsdfoundation.org/about-us/about-the-foundation/project/
-        case 'cygwin*'
+        case 'cygwin*' 'mingw*_nt*' 'msys_nt*'
             printf %s\n  FFFFFF 00CCFF # https://answers.microsoft.com/en-us/windows/forum/all/what-is-the-official-windows-8-blue-rgb-or-hex/fd57144b-f69b-42d8-8c21-6ca911646e44
         case linux
             if test (uname -o) = Android


### PR DESCRIPTION
#### Description

Msys2 is another linux on windows project, based off of cygwin. Fish runs in it perfectly fine, but it has a different `uname`, so tide's os detection fails.

Specifically, depending on exactly which of it's environments you run, I saw the following outputs. I'm running windows 10 build 19044, with 64bit msys.
Environment | Output
:---|:---
MSYS | `MSYS_NT-10.0-19044`
UCRT64 | `MINGW64_NT-10.0-19044`
CLANG64 | `MINGW64_NT-10.0-19044`
CLANGARM64 | `MINGW64_NT-10.0-19044`
CLANG32 | `MINGW32_NT-10.0-19044`
MINGW64 | `MINGW64_NT-10.0-19044`
MINGW32 | `MINGW32_NT-10.0-19044`

This also lines up with what I can gleam from the source [here](https://github.com/git-for-windows/msys2-runtime/blob/27eb5a5265aa58adadf4d702dfe10467ba233d58/winsup/cygwin/uname.cc#L27) and [here](https://github.com/git-for-windows/msys2-runtime/blob/27eb5a5265aa58adadf4d702dfe10467ba233d58/winsup/cygwin/wincap.cc#L513).

It's worth noting `uname -o` returns `Msys` on every one, but I felt like checking that would over complicate the code a bit, better to stick to the established pattern.

#### How Has This Been Tested

To test I installed the changes, then ran `_tide_detect_os` from shell. Tested in all 6 msys environments, and a wsl ubuntu install.

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

- [ ] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.

Is there any work to be done here? Happy to help.