### PR TITLE
FEAT: character icon for root

### DIFF
--- a/functions/_tide_item_character.fish
+++ b/functions/_tide_item_character.fish
@@ -3,7 +3,9 @@ function _tide_item_character
 
     set -q add_prefix || echo -ns ' '
 
-    test "$fish_key_bindings" = fish_default_key_bindings && echo -ns $tide_character_icon ||
+    if test "$fish_key_bindings" = fish_default_key_bindings
+        ! fish_is_root_user && echo -ns $tide_character_icon || echo -ns $tide_character_icon_root
+    else
         switch $fish_bind_mode
             case insert
                 echo -ns $tide_character_icon
@@ -14,4 +16,5 @@ function _tide_item_character
             case visual
                 echo -ns $tide_character_vi_icon_visual
         end
+    end
 end

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -4,6 +4,7 @@ tide_aws_icon 
 tide_character_color $_tide_color_green
 tide_character_color_failure FF0000
 tide_character_icon ❯
+tide_character_icon_root \#
 tide_character_vi_icon_default ❮
 tide_character_vi_icon_replace ▶
 tide_character_vi_icon_visual V

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -4,6 +4,7 @@ tide_aws_icon 
 tide_character_color $_tide_color_green
 tide_character_color_failure FF0000
 tide_character_icon ❯
+tide_character_icon_root \#
 tide_character_vi_icon_default ❮
 tide_character_vi_icon_replace ▶
 tide_character_vi_icon_visual V

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -4,6 +4,7 @@ tide_aws_icon 
 tide_character_color $_tide_color_green
 tide_character_color_failure FF0000
 tide_character_icon ❯
+tide_character_icon_root \#
 tide_character_vi_icon_default ❮
 tide_character_vi_icon_replace ▶
 tide_character_vi_icon_visual V


### PR DESCRIPTION
#### Description

add `tide_character_icon_root` (default: `#`)

pretty simple feature, not much to go wrong. tested on linux.
if you like it, i'm happy to update the wiki, other documentation, or whatever else you want. lmk.

<img width="380" alt="image" src="https://user-images.githubusercontent.com/9761890/227000303-d8b33bc1-4ae5-492a-b8c3-5c5a5d98df6f.png">
