### PR TITLE
add gcloud

### DIFF
--- a/functions/_tide_item_gcloud.fish
+++ b/functions/_tide_item_gcloud.fish
@@ -1,0 +1,8 @@
+function _tide_item_gcloud
+    set -q CLOUDSDK_CONFIG || set -l CLOUDSDK_CONFIG ~/.config/gcloud
+    path is $CLOUDSDK_CONFIG/active_config \
+        && read -l config <$CLOUDSDK_CONFIG/active_config \
+        && path is $CLOUDSDK_CONFIG/configurations/config_$config \
+        && string match -rg '^\s*project\s*=\s*(.*)' <$CLOUDSDK_CONFIG/configurations/config_$config | read -l project \
+        && _tide_print_item gcloud $tide_gcloud_icon' ' $project
+end

--- a/functions/_tide_item_gcloud.fish
+++ b/functions/_tide_item_gcloud.fish
@@ -3,6 +3,6 @@ function _tide_item_gcloud
     path is $CLOUDSDK_CONFIG/active_config \
         && read -l config <$CLOUDSDK_CONFIG/active_config \
         && path is $CLOUDSDK_CONFIG/configurations/config_$config \
-        && string match -rg '^\s*project\s*=\s*(.*)' <$CLOUDSDK_CONFIG/configurations/config_$config | read -l project \
+        && string match -qr '^\s*project\s*=\s*(?<project>.*)' <$CLOUDSDK_CONFIG/configurations/config_$config \
         && _tide_print_item gcloud $tide_gcloud_icon' ' $project
 end

--- a/functions/_tide_remove_unusable_items.fish
+++ b/functions/_tide_remove_unusable_items.fish
@@ -1,7 +1,7 @@
 function _tide_remove_unusable_items
     # Remove tool-specific items for tools the machine doesn't have installed
     set -l removed_items
-    for item in aws chruby crystal distrobox docker elixir git go java kubectl nix_shell node php pulumi rustc terraform toolbox virtual_env
+    for item in aws chruby crystal distrobox docker elixir gcloud git go java kubectl nix_shell node php pulumi rustc terraform toolbox virtual_env
         set -l cli_names $item
         switch $item
             case distrobox # there is no 'distrobox' command inside the container

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -34,6 +34,9 @@ tide_docker_icon 
 tide_elixir_bg_color 444444
 tide_elixir_color 4E2A8E
 tide_elixir_icon 
+tide_gcloud_bg_color 444444
+tide_gcloud_color 4285F4
+tide_gcloud_icon 
 tide_git_bg_color 444444
 tide_git_bg_color_unstable 444444
 tide_git_bg_color_urgent 444444
@@ -99,7 +102,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable 
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php pulumi chruby go kubectl distrobox toolbox terraform aws nix_shell crystal elixir
+tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php pulumi chruby go gcloud kubectl distrobox toolbox terraform aws nix_shell crystal elixir
 tide_right_prompt_prefix 
 tide_right_prompt_separator_diff_color 
 tide_right_prompt_separator_same_color 

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -18,6 +18,8 @@ tide_docker_bg_color black
 tide_docker_color blue
 tide_elixir_bg_color black
 tide_elixir_color magenta
+tide_gcloud_bg_color black
+tide_gcloud_color blue
 tide_git_bg_color black
 tide_git_bg_color_unstable black
 tide_git_bg_color_urgent black

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -34,6 +34,9 @@ tide_docker_icon 
 tide_elixir_bg_color normal
 tide_elixir_color 4E2A8E
 tide_elixir_icon 
+tide_gcloud_bg_color normal
+tide_gcloud_color 4285F4
+tide_gcloud_icon 
 tide_git_bg_color normal
 tide_git_bg_color_unstable normal
 tide_git_bg_color_urgent normal
@@ -99,7 +102,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable 
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled false
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php pulumi chruby go kubectl distrobox toolbox terraform aws nix_shell crystal elixir
+tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php pulumi chruby go gcloud kubectl distrobox toolbox terraform aws nix_shell crystal elixir
 tide_right_prompt_prefix ' '
 tide_right_prompt_separator_diff_color ' '
 tide_right_prompt_separator_same_color ' '

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -18,6 +18,8 @@ tide_docker_bg_color normal
 tide_docker_color blue
 tide_elixir_bg_color normal
 tide_elixir_color magenta
+tide_gcloud_bg_color normal
+tide_gcloud_color blue
 tide_git_bg_color normal
 tide_git_bg_color_unstable normal
 tide_git_bg_color_urgent normal

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -34,6 +34,9 @@ tide_docker_icon 
 tide_elixir_bg_color 4E2A8E
 tide_elixir_color 000000
 tide_elixir_icon 
+tide_gcloud_bg_color 4285F4
+tide_gcloud_color 000000
+tide_gcloud_icon 
 tide_git_bg_color 4E9A06
 tide_git_bg_color_unstable C4A000
 tide_git_bg_color_urgent CC0000
@@ -99,7 +102,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable 
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php pulumi chruby go kubectl distrobox toolbox terraform aws nix_shell crystal elixir
+tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php pulumi chruby go gcloud kubectl distrobox toolbox terraform aws nix_shell crystal elixir
 tide_right_prompt_prefix 
 tide_right_prompt_separator_diff_color 
 tide_right_prompt_separator_same_color 

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -18,6 +18,8 @@ tide_docker_bg_color blue
 tide_docker_color black
 tide_elixir_bg_color magenta
 tide_elixir_color black
+tide_gcloud_bg_color blue
+tide_gcloud_color black
 tide_git_bg_color green
 tide_git_bg_color_unstable yellow
 tide_git_bg_color_urgent red

--- a/tests/_tide_item_gcloud.test.fish
+++ b/tests/_tide_item_gcloud.test.fish
@@ -1,0 +1,23 @@
+# RUN: %fish %s
+_tide_parent_dirs
+
+function _gcloud
+    _tide_decolor (_tide_item_gcloud)
+end
+
+set -lx tide_gcloud_icon G
+set -l tmpdir (mktemp -d)
+cd $tmpdir
+set -lx HOME $tmpdir
+
+_gcloud # CHECK:
+
+mkdir -p $tmpdir/.config/gcloud
+echo default >$tmpdir/.config/gcloud/active_config
+_gcloud # CHECK:
+
+mkdir -p $tmpdir/.config/gcloud/configurations
+echo "project = test" >$tmpdir/.config/gcloud/configurations/config_default
+_gcloud # CHECK: G test
+
+command rm -r $tmpdir


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Description

<!-- Describe your changes. -->

Adds a `gcloud` item to display the current project (like p10k). For performance, it reads the config files directly rather than invoking `gcloud config get-value project` (which takes ~350ms on my machine)

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- Closes # - Please link to an open issue. -->

#### Screenshots (if appropriate)

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [ ] I have tested using **Linux**.
- [x] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I am ready to update the wiki accordingly.
- [x] I have updated the tests accordingly.
