### PR TITLE
fix: linux mint os selection

### DIFF
--- a/functions/_tide_detect_os.fish
+++ b/functions/_tide_detect_os.fish
@@ -53,7 +53,7 @@ function _tide_detect_os_linux_cases -a file key
             printf %s\n  FFFFFF 262F45 # https://wiki.mageia.org/en/Artwork_guidelines
         case manjaro
             printf %s\n  FFFFFF 35BF5C # from https://gitlab.manjaro.org/artwork/branding/logo/-/blob/master/logo.svg
-        case mint
+        case mint linuxmint
             printf %s\n  FFFFFF 69B53F # extracted from https://linuxmint.com/web/img/favicon.ico
         case nixos
             printf %s\n  FFFFFF 5277C3 # https://github.com/NixOS/nixos-artwork/tree/master/logo

--- a/tests/detect_os/_tide_detect_os.test.fish
+++ b/tests/detect_os/_tide_detect_os.test.fish
@@ -32,3 +32,8 @@ _detect_os_linux_cases opensuse-etc-release
 # CHECK: 
 # CHECK: 73BA25
 # CHECK: 173f4f
+
+_detect_os_linux_cases linuxmint-etc-release
+# CHECK: 
+# CHECK: FFFFFF
+# CHECK: 69B53F

--- a/tests/detect_os/linuxmint-etc-release
+++ b/tests/detect_os/linuxmint-etc-release
@@ -1,0 +1,12 @@
+NAME="Linux Mint"
+VERSION="20.3 (Una)"
+ID=linuxmint
+ID_LIKE=ubuntu
+PRETTY_NAME="Linux Mint 20.3"
+VERSION_ID="20.3"
+HOME_URL="https://www.linuxmint.com/"
+SUPPORT_URL="https://forums.linuxmint.com/"
+BUG_REPORT_URL="http://linuxmint-troubleshooting-guide.readthedocs.io/en/latest/"
+PRIVACY_POLICY_URL="https://www.linuxmint.com/"
+VERSION_CODENAME=una
+UBUNTU_CODENAME=focal


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Description
Fixes the linux mint logo at linux mint system.

<!-- Describe your changes. -->

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### Motivation and Context
The icon at `linuxmint` system were being displayed as `ubuntu` system.

<!-- Why is this change required? What problem does it solve? -->

 <!--- Please link to an open issue. -->

#### Screenshots (if appropriate)
Running it before the change at Linux mint:
![image](https://user-images.githubusercontent.com/53790796/229303631-5e859e87-62b9-4e77-b2a5-550bc26feecc.png)

Running it before the change:
![image](https://user-images.githubusercontent.com/53790796/229303665-3b0c3aff-19a6-444e-8146-48a92e7a1cb4.png)

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I am ready to update the wiki accordingly.
- [x] I have updated the tests accordingly.
