### PR TITLE
add direnv

### DIFF
--- a/functions/_tide_item_direnv.fish
+++ b/functions/_tide_item_direnv.fish
@@ -1,6 +1,6 @@
 function _tide_item_direnv
     set -q DIRENV_DIR || return
-    direnv status | string match -qr '^Found RC allowed false$' \
+    direnv status | string match -q 'Found RC allowed false' \
         && set -lx tide_direnv_color $tide_direnv_color_denied \
         && set -lx tide_direnv_bg_color $tide_direnv_bg_color_denied
     _tide_print_item direnv $tide_direnv_icon

--- a/functions/_tide_item_direnv.fish
+++ b/functions/_tide_item_direnv.fish
@@ -1,0 +1,7 @@
+function _tide_item_direnv
+    set -q DIRENV_DIR || return
+    direnv status | string match -qr '^Found RC allowed false$' \
+        && set -lx tide_direnv_color $tide_direnv_color_denied \
+        && set -lx tide_direnv_bg_color $tide_direnv_bg_color_denied
+    _tide_print_item direnv $tide_direnv_icon
+end

--- a/functions/_tide_remove_unusable_items.fish
+++ b/functions/_tide_remove_unusable_items.fish
@@ -1,7 +1,7 @@
 function _tide_remove_unusable_items
     # Remove tool-specific items for tools the machine doesn't have installed
     set -l removed_items
-    for item in aws chruby crystal distrobox docker elixir gcloud git go java kubectl nix_shell node php pulumi rustc terraform toolbox virtual_env
+    for item in aws chruby crystal direnv distrobox docker elixir gcloud git go java kubectl nix_shell node php pulumi rustc terraform toolbox virtual_env
         set -l cli_names $item
         switch $item
             case distrobox # there is no 'distrobox' command inside the container

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -24,6 +24,11 @@ tide_context_hostname_parts 1
 tide_crystal_bg_color 444444
 tide_crystal_color FFFFFF
 tide_crystal_icon ⬢
+tide_direnv_bg_color 444444
+tide_direnv_bg_color_denied 444444
+tide_direnv_color $_tide_color_gold
+tide_direnv_color_denied FF0000
+tide_direnv_icon ▼
 tide_distrobox_bg_color 444444
 tide_distrobox_color FF00FF
 tide_distrobox_icon ⬢
@@ -102,7 +107,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable 
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php pulumi chruby go gcloud kubectl distrobox toolbox terraform aws nix_shell crystal elixir
+tide_right_prompt_items status cmd_duration context jobs direnv node virtual_env rustc java php pulumi chruby go gcloud kubectl distrobox toolbox terraform aws nix_shell crystal elixir
 tide_right_prompt_prefix 
 tide_right_prompt_separator_diff_color 
 tide_right_prompt_separator_same_color 

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -12,6 +12,11 @@ tide_context_color_root bryellow
 tide_context_color_ssh yellow
 tide_crystal_bg_color black
 tide_crystal_color brwhite
+tide_direnv_bg_color black
+tide_direnv_bg_color_denied black
+tide_direnv_color bryellow
+tide_direnv_color_denied brred
+tide_direnv_icon ▼
 tide_distrobox_bg_color black
 tide_distrobox_color brmagenta
 tide_docker_bg_color black

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -16,7 +16,6 @@ tide_direnv_bg_color black
 tide_direnv_bg_color_denied black
 tide_direnv_color bryellow
 tide_direnv_color_denied brred
-tide_direnv_icon ▼
 tide_distrobox_bg_color black
 tide_distrobox_color brmagenta
 tide_docker_bg_color black

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -24,6 +24,11 @@ tide_context_hostname_parts 1
 tide_crystal_bg_color normal
 tide_crystal_color FFFFFF
 tide_crystal_icon ⬢
+tide_direnv_bg_color normal
+tide_direnv_bg_color_denied normal
+tide_direnv_color $_tide_color_gold
+tide_direnv_color_denied FF0000
+tide_direnv_icon ▼
 tide_distrobox_bg_color normal
 tide_distrobox_color FF00FF
 tide_distrobox_icon ⬢
@@ -102,7 +107,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable 
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled false
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php pulumi chruby go gcloud kubectl distrobox toolbox terraform aws nix_shell crystal elixir
+tide_right_prompt_items status cmd_duration context jobs direnv node virtual_env rustc java php pulumi chruby go gcloud kubectl distrobox toolbox terraform aws nix_shell crystal elixir
 tide_right_prompt_prefix ' '
 tide_right_prompt_separator_diff_color ' '
 tide_right_prompt_separator_same_color ' '

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -12,6 +12,11 @@ tide_context_color_root bryellow
 tide_context_color_ssh yellow
 tide_crystal_bg_color normal
 tide_crystal_color brwhite
+tide_direnv_bg_color normal
+tide_direnv_bg_color_denied normal
+tide_direnv_color bryellow
+tide_direnv_color_denied brred
+tide_direnv_icon ▼
 tide_distrobox_bg_color normal
 tide_distrobox_color brmagenta
 tide_docker_bg_color normal

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -16,7 +16,6 @@ tide_direnv_bg_color normal
 tide_direnv_bg_color_denied normal
 tide_direnv_color bryellow
 tide_direnv_color_denied brred
-tide_direnv_icon ▼
 tide_distrobox_bg_color normal
 tide_distrobox_color brmagenta
 tide_docker_bg_color normal

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -24,6 +24,11 @@ tide_context_hostname_parts 1
 tide_crystal_bg_color FFFFFF
 tide_crystal_color 000000
 tide_crystal_icon ⬢
+tide_direnv_bg_color $_tide_color_gold
+tide_direnv_bg_color_denied FF0000
+tide_direnv_color 000000
+tide_direnv_color_denied 000000
+tide_direnv_icon ▼
 tide_distrobox_bg_color FF00FF
 tide_distrobox_color 000000
 tide_distrobox_icon ⬢
@@ -102,7 +107,7 @@ tide_pwd_icon_home
 tide_pwd_icon_unwritable 
 tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration context jobs node virtual_env rustc java php pulumi chruby go gcloud kubectl distrobox toolbox terraform aws nix_shell crystal elixir
+tide_right_prompt_items status cmd_duration context jobs direnv node virtual_env rustc java php pulumi chruby go gcloud kubectl distrobox toolbox terraform aws nix_shell crystal elixir
 tide_right_prompt_prefix 
 tide_right_prompt_separator_diff_color 
 tide_right_prompt_separator_same_color 

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -16,7 +16,6 @@ tide_direnv_bg_color bryellow
 tide_direnv_bg_color_denied brred
 tide_direnv_color black
 tide_direnv_color_denied black
-tide_direnv_icon ▼
 tide_distrobox_bg_color brmagenta
 tide_distrobox_color black
 tide_docker_bg_color blue

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -12,6 +12,11 @@ tide_context_color_root yellow
 tide_context_color_ssh yellow
 tide_crystal_bg_color brwhite
 tide_crystal_color black
+tide_direnv_bg_color bryellow
+tide_direnv_bg_color_denied brred
+tide_direnv_color black
+tide_direnv_color_denied black
+tide_direnv_icon ▼
 tide_distrobox_bg_color brmagenta
 tide_distrobox_color black
 tide_docker_bg_color blue

--- a/tests/_tide_item_direnv.test.fish
+++ b/tests/_tide_item_direnv.test.fish
@@ -1,0 +1,18 @@
+# RUN: %fish %s
+_tide_parent_dirs
+
+function _direnv
+    _tide_decolor (_tide_item_direnv)
+end
+
+set -e DIRENV_DIR
+set -lx tide_direnv_icon ▼
+
+_direnv # CHECK:
+
+set -lx DIRENV_DIR
+mock direnv status "echo Found RC allowed true"
+_direnv # CHECK: ▼
+
+mock direnv status "echo Found RC allowed false"
+_direnv # CHECK: ▼


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Description

<!-- Describe your changes. -->

Adds a [`direnv`](https://github.com/direnv/direnv) item to show its status, using the same color/icon as p10k.
The only addition is showing a different color when direnv will be active once the user allows it's execution.

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

As a brief background, direnv can be in three states for a given working directory:

1. Inactive (`.envrc` file does not exist)
1. Disallowed (`.envrc` exists but not yet executed as the user needs to explicitly allow it)
1. Active (`.envrc` exists and was executed)

This calls `direnv status` to distinguish between the last two states, which only takes ~12ms on my machine.
Note this won't be needed once https://github.com/direnv/direnv/pull/1010 has been merged.

#### Screenshots (if appropriate)

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [ ] I have tested using **Linux**.
- [x] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I am ready to update the wiki accordingly.
- [x] I have updated the tests accordingly.
