### PR TITLE
Feature: Truncate kubectl context using variables

### DIFF
--- a/functions/_tide_item_kubectl.fish
+++ b/functions/_tide_item_kubectl.fish
@@ -1,4 +1,4 @@
 function _tide_item_kubectl
-    kubectl config view --minify --output 'jsonpath={.current-context}/{..namespace}' 2>/dev/null | read -l context &&
+    kubectl config view --minify --output 'jsonpath={.current-context}/{..namespace}' 2>/dev/null | string shorten -"$tide_kubectl_truncation_strategy"m"$tide_kubectl_truncation_length" | read -l context &&
         _tide_print_item kubectl $tide_kubectl_icon' ' (string replace -r '/(|default)$' '' $context)
 end


### PR DESCRIPTION
Truncate `kubectl` output using environment variables.

<!-- Provide a general summary of your changes in the Title above. -->

#### Description

Requires the following variables to be defined.

Example variable definition:
```sh
set -x tide_kubectl_truncation_strategy l
set -x tide_kubectl_truncation_length 31
```

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### Motivation and Context

My `kubectl` context is too large and almost fills an entire line.

Same approach as in:
https://github.com/IlanCosman/tide/blob/447945d2cff8f70d5c791dd4eec8b322d37798dd/functions/_tide_item_git.fish#L2
<!-- Why is this change required? What problem does it solve? -->

Closes # <!--- Please link to an open issue. -->

#### Screenshots (if appropriate)

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
I tested the changes by modifying the file `$HOME/.config/fish/functions/_tide_item_kubectl.fish`.
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [ ] I have tested using **Linux**.
- [x] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.
