### PR TITLE
Only remove unusable items if they were going to be used

### DIFF
--- a/functions/_tide_remove_unusable_items.fish
+++ b/functions/_tide_remove_unusable_items.fish
@@ -1,7 +1,13 @@
 function _tide_remove_unusable_items
     # Remove tool-specific items for tools the machine doesn't have installed
     set -l removed_items
-    for item in aws chruby crystal direnv distrobox docker elixir gcloud git go java kubectl nix_shell node php pulumi rustc terraform toolbox virtual_env
+    for item in aws chruby crystal docker git go java kubectl nix_shell node php rustc terraform toolbox virtual_env
+
+        # Only search for removal if the item is specified in the left or right prompt
+        if not contains $item $tide_left_prompt_items && not contains $item $tide_right_prompt_items
+            continue
+        end
+
         set -l cli_names $item
         switch $item
             case distrobox # there is no 'distrobox' command inside the container


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Motivation and Context

On my setup (fish v3.6.1, Ubuntu 22.04, Windows 10 WSL2) the repeated calls to `type --query $cli_names` in `_tide_remove_unusable_items` causes noticeable lag when starting a new shell. Checking if the cli items are in the left or right prompt before doing the `type --query` speeds up `_tide_remove_unusable_items` for me by ~4.5x

#### How Has This Been Tested

I run fish with tide as my daily driver; I made the changes locally and ran with them for a couple days. I also ran `make test`, which passed.

- [X] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.
