### PR TITLE
Display Python version in virtual_env item

### DIFF
--- a/functions/_tide_item_virtual_env.fish
+++ b/functions/_tide_item_virtual_env.fish
@@ -1,11 +1,16 @@
 function _tide_item_virtual_env
-    test -n "$VIRTUAL_ENV" && split_virtual_env=(string split / "$VIRTUAL_ENV") if test $split_virtual_env[-2] = virtualenvs
+    test -n "$VIRTUAL_ENV" || return
+
+    set -l split_virtual_env (string split / "$VIRTUAL_ENV")
+    set -l python_version (python --version | string split ' ')[2]
+
+    if test $split_virtual_env[-2] = virtualenvs
         # pipenv $VIRTUAL_ENV looks like /home/ilan/.local/share/virtualenvs/pipenv_project-EwRYuc3l
         # Detect whether we are using pipenv by looking for virtualenvs. If so, remove the hash at the end.
-        _tide_print_item virtual_env $tide_virtual_env_icon' ' (string split -r -m1 - "$split_virtual_env[-1]")[1]
+        _tide_print_item virtual_env $tide_virtual_env_icon' ' $python_version ' ('(string split -r -m1 - "$split_virtual_env[-1]")[1]')'
     else if contains -- $split_virtual_env[-1] virtualenv venv .venv env # avoid generic names
-        _tide_print_item virtual_env $tide_virtual_env_icon' ' $split_virtual_env[-2]
+        _tide_print_item virtual_env $tide_virtual_env_icon' ' $python_version ' ('$split_virtual_env[-2]')'
     else
-        _tide_print_item virtual_env $tide_virtual_env_icon' ' $split_virtual_env[-1]
+        _tide_print_item virtual_env $tide_virtual_env_icon' ' $python_version ' ('$split_virtual_env[-1]')'
     end
 end

--- a/tests/_tide_item_virtual_env.test.fish
+++ b/tests/_tide_item_virtual_env.test.fish
@@ -5,16 +5,17 @@ function _virtual_env
     _tide_decolor (_tide_item_virtual_env)
 end
 
+mock python --version "echo Python 3.11.3"
 set -lx tide_virtual_env_icon 
 
 set -lx VIRTUAL_ENV
 _virtual_env # CHECK:
 
 set -lx VIRTUAL_ENV /home/ilan/python_project/non-generic-name
-_virtual_env # CHECK:  non-generic-name
+_virtual_env # CHECK:  3.11.3 (non-generic-name)
 
 set -lx VIRTUAL_ENV /home/ilan/python_project/venv
-_virtual_env # CHECK:  python_project
+_virtual_env # CHECK:  3.11.3 (python_project)
 
 set -lx VIRTUAL_ENV /home/ilan/.local/share/virtualenvs/pipenv_project-EwRYuc3l
-_virtual_env # CHECK:  pipenv_project
+_virtual_env # CHECK:  3.11.3 (pipenv_project)


### PR DESCRIPTION
#### Description

Display Python version alongside virtual env name.

#### Motivation and Context

When working on multiple Python projects I often have to deal with different Python versions. The version is just as important as the virtual env name.

#### Screenshots (if appropriate)

![2023-06-15_19:58:06](https://github.com/IlanCosman/tide/assets/8322846/40a8efe6-c253-4190-9679-a9006eaed972)

#### How Has This Been Tested

Tested with a few virtual envs I have lying around, adjusted tests, ran `make test`.

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I am ready to update the wiki accordingly.
- [x] I have updated the tests accordingly.
