### PR TITLE
Add newline before prompt only when previous output exists

### DIFF
--- a/conf.d/_tide_init.fish
+++ b/conf.d/_tide_init.fish
@@ -1,6 +1,8 @@
 function _tide_init_install --on-event _tide_init_install
     set -U VIRTUAL_ENV_DISABLE_PROMPT true
 
+    set --global _tide_fresh_session true
+    
     source (functions --details _tide_sub_configure)
     _load_config lean
     _tide_finish

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -20,7 +20,7 @@ function _tide_refresh_prompt --on-variable $prompt_var --on-variable COLUMNS
 end
 
 if contains newline $_tide_left_items # two line prompt initialization
-    test "$tide_prompt_add_newline_before" = true && set -l add_newline '\n'
+    test "$tide_prompt_add_newline_before" = true && test "$_tide_fresh_session" = false && set -l add_newline '\n'
 
     set_color $tide_prompt_color_frame_and_connection -b normal | read -l prompt_and_frame_color
 
@@ -58,7 +58,7 @@ function fish_right_prompt
     string unescape \"\$$prompt_var[1][4]$bot_right_frame$color_normal\"
 end"
 else # one line prompt initialization
-    test "$tide_prompt_add_newline_before" = true && set -l add_newline '\0'
+    test "$tide_prompt_add_newline_before" = true && test "$_tide_fresh_session" = false && set -l add_newline '\0'
 
     math 5 -$tide_prompt_min_cols | read -l column_offset
     test $column_offset -ge 0 && set column_offset "+$column_offset"

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -88,3 +88,5 @@ end
 eval "function _tide_on_fish_exit --on-event fish_exit
     set -e $prompt_var
 end"
+
+set _tide_fresh_session false


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Description

<!-- Describe your changes. -->

As #327 described, a newline is printed when there is no previous output. With this PR, the newline is omitted when the terminal is first opened or cleared using Ctrl-L.

Referred to the implementation from pure-fish, specifically in the files [_pure_prompt_new_line.fish](https://github.com/pure-fish/pure/blob/c0b83abec7197a0d06adc9ffe82d21d5a8c5f865/functions/_pure_prompt_new_line.fish#L6) and [_pure_init.fish](https://github.com/pure-fish/pure/blob/c0b83abec7197a0d06adc9ffe82d21d5a8c5f865/conf.d/_pure_init.fish#L5).

BTW, feel free to squash commits when merging!

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Closes #327 

#### Screenshots (if appropriate)

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [ ] I have tested using **Linux**.
- [x] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.
