### PR TITLE
Skip rebase/cherry-pick progress when it is absent

### DIFF
--- a/functions/_tide_item_git.fish
+++ b/functions/_tide_item_git.fish
@@ -14,16 +14,14 @@ function _tide_item_git
 
     # Operation
     if test -d $gdir/rebase-merge
-        # Turn ANY into ALL, via double negation.
-        if not path is --invert $gdir/rebase-merge/{msgnum,end}
+        # Turn ANY into ALL, via double negation
+        if not path is -v $gdir/rebase-merge/{msgnum,end}
             read -f step <$gdir/rebase-merge/msgnum
             read -f total_steps <$gdir/rebase-merge/end
         end
-        test -f $gdir/rebase-merge/interactive \
-            && set -f operation rebase-i || set -f operation rebase-m
+        test -f $gdir/rebase-merge/interactive && set -f operation rebase-i || set -f operation rebase-m
     else if test -d $gdir/rebase-apply
-        # Turn ANY into ALL, via double negation.
-        if not path is --invert $gdir/rebase-apply/{next,last}
+        if not path is -v $gdir/rebase-apply/{next,last}
             read -f step <$gdir/rebase-apply/next
             read -f total_steps <$gdir/rebase-apply/last
         end

--- a/functions/_tide_item_git.fish
+++ b/functions/_tide_item_git.fish
@@ -14,12 +14,19 @@ function _tide_item_git
 
     # Operation
     if test -d $gdir/rebase-merge
-        read -f step <$gdir/rebase-merge/msgnum
-        read -f total_steps <$gdir/rebase-merge/end
-        test -f $gdir/rebase-merge/interactive && set -f operation rebase-i || set -f operation rebase-m
+        # Turn ANY into ALL, via double negation.
+        if not path is --invert $gdir/rebase-merge/{msgnum,end}
+            read -f step <$gdir/rebase-merge/msgnum
+            read -f total_steps <$gdir/rebase-merge/end
+        end
+        test -f $gdir/rebase-merge/interactive \
+            && set -f operation rebase-i || set -f operation rebase-m
     else if test -d $gdir/rebase-apply
-        read -f step <$gdir/rebase-apply/next
-        read -f total_steps <$gdir/rebase-apply/last
+        # Turn ANY into ALL, via double negation.
+        if not path is --invert $gdir/rebase-apply/{next,last}
+            read -f step <$gdir/rebase-apply/next
+            read -f total_steps <$gdir/rebase-apply/last
+        end
         if test -f $gdir/rebase-apply/rebasing
             set -f operation rebase
         else if test -f $gdir/rebase-apply/applying


### PR DESCRIPTION
#### Description

Even when git is in rebase or cherry-pick mode, plan execution progress might be absent.
For example, when the plan is not prepared just yet - while `git rebase --interactive` is waiting for the editor to finish editing the rebase plan.

Here is a report of this issue: https://github.com/IlanCosman/tide/issues/378

Closes #378 

#### How Has This Been Tested

Only tested manually.  Not sure how to construct an automatic test for this case.
I do not have MacOS, but considering I am using commands that are already there, it should work on MacOS.

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

- [ ] I am ready to update the wiki accordingly.
  Does not seem to apply, as this is a bug fix.

- [ ] I have updated the tests accordingly.
  There are no automated tests that check rebase progress.
  For this particular case, it is even more nuanced, as we need to verify output while the interactive rebase command is waiting for the editor to exit.
  So, I just fixed the code.

  I only checked `git rebase`, but it does not seem to hurt to make a similar check for the `cherry-pick` case.