### PR TITLE
fix prompt: Guard against missing 'node' command (#431)

### DIFF
--- a/functions/_tide_item_node.fish
+++ b/functions/_tide_item_node.fish
@@ -1,5 +1,5 @@
 function _tide_item_node
-    if path is $_tide_parent_dirs/package.json
+    if command -q node && path is $_tide_parent_dirs/package.json
         node --version | string match -qr "v(?<v>.*)"
         _tide_print_item node $tide_node_icon' ' $v
     end


### PR DESCRIPTION
Fix `_tide_item_node` Function in Prompt

<!-- Provide a general summary of your changes in the Title above. -->

#### Description

Implemented a check for the node command's availability in the _tide_item_node function before attempting to retrieve its version. This prevents potential errors in environments where Node.js is uninstalled or Node.js is exclusively used in containers.
