### PR TITLE
Add Zig item

### DIFF
--- a/functions/_tide_item_zig.fish
+++ b/functions/_tide_item_zig.fish
@@ -1,0 +1,6 @@
+function _tide_item_zig
+    if path is $_tide_parent_dirs/build.zig
+        zig version | string match -qr "(?<v>[\d.]+(-dev)?)"
+        _tide_print_item zig $tide_zig_icon' ' $v
+    end
+end

--- a/functions/_tide_remove_unusable_items.fish
+++ b/functions/_tide_remove_unusable_items.fish
@@ -1,7 +1,7 @@
 function _tide_remove_unusable_items
     # Remove tool-specific items for tools the machine doesn't have installed
     set -l removed_items
-    for item in aws crystal direnv distrobox docker elixir gcloud git go java kubectl nix_shell node php pulumi python ruby rustc terraform toolbox
+    for item in aws crystal direnv distrobox docker elixir gcloud git go java kubectl nix_shell node php pulumi python ruby rustc terraform toolbox zig
         contains $item $tide_left_prompt_items $tide_right_prompt_items || continue
 
         set -l cli_names $item

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -76,11 +76,11 @@ tide_pwd_bg_color 444444
 tide_pwd_color_anchors $_tide_color_light_blue
 tide_pwd_color_dirs $_tide_color_dark_blue
 tide_pwd_color_truncated_dirs 8787AF
-tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
+tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json build.zig
 tide_python_bg_color 444444
 tide_python_color 00AFAF
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration context jobs direnv node python rustc java php pulumi ruby go gcloud kubectl distrobox toolbox terraform aws nix_shell crystal elixir
+tide_right_prompt_items status cmd_duration context jobs direnv node python rustc java php pulumi ruby go gcloud kubectl distrobox toolbox terraform aws nix_shell crystal elixir zig
 tide_right_prompt_prefix 
 tide_right_prompt_separator_diff_color 
 tide_right_prompt_separator_same_color 
@@ -111,3 +111,5 @@ tide_vi_mode_color_default 949494
 tide_vi_mode_color_insert 87AFAF
 tide_vi_mode_color_replace 87AF87
 tide_vi_mode_color_visual FF8700
+tide_zig_bg_color 444444
+tide_zig_color F7A41D

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -85,3 +85,5 @@ tide_vi_mode_color_default white
 tide_vi_mode_color_insert cyan
 tide_vi_mode_color_replace green
 tide_vi_mode_color_visual yellow
+tide_zig_bg_color black
+tide_zig_color yellow

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -76,11 +76,11 @@ tide_pwd_bg_color normal
 tide_pwd_color_anchors $_tide_color_light_blue
 tide_pwd_color_dirs $_tide_color_dark_blue
 tide_pwd_color_truncated_dirs 8787AF
-tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
+tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json build.zig
 tide_python_bg_color normal
 tide_python_color 00AFAF
 tide_right_prompt_frame_enabled false
-tide_right_prompt_items status cmd_duration context jobs direnv node python rustc java php pulumi ruby go gcloud kubectl distrobox toolbox terraform aws nix_shell crystal elixir
+tide_right_prompt_items status cmd_duration context jobs direnv node python rustc java php pulumi ruby go gcloud kubectl distrobox toolbox terraform aws nix_shell crystal elixir zig
 tide_right_prompt_prefix ' '
 tide_right_prompt_separator_diff_color ' '
 tide_right_prompt_separator_same_color ' '
@@ -111,3 +111,5 @@ tide_vi_mode_color_default 949494
 tide_vi_mode_color_insert 87AFAF
 tide_vi_mode_color_replace 87AF87
 tide_vi_mode_color_visual FF8700
+tide_zig_bg_color normal
+tide_zig_color F7A41D

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -85,3 +85,5 @@ tide_vi_mode_color_default white
 tide_vi_mode_color_insert cyan
 tide_vi_mode_color_replace green
 tide_vi_mode_color_visual yellow
+tide_zig_bg_color normal
+tide_zig_color yellow

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -76,11 +76,11 @@ tide_pwd_bg_color 3465A4
 tide_pwd_color_anchors E4E4E4
 tide_pwd_color_dirs E4E4E4
 tide_pwd_color_truncated_dirs BCBCBC
-tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json
+tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform Cargo.toml composer.json CVS go.mod package.json build.zig
 tide_python_bg_color 444444
 tide_python_color 00AFAF
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration context jobs direnv node python rustc java php pulumi ruby go gcloud kubectl distrobox toolbox terraform aws nix_shell crystal elixir
+tide_right_prompt_items status cmd_duration context jobs direnv node python rustc java php pulumi ruby go gcloud kubectl distrobox toolbox terraform aws nix_shell crystal elixir zig
 tide_right_prompt_prefix 
 tide_right_prompt_separator_diff_color 
 tide_right_prompt_separator_same_color 
@@ -111,3 +111,5 @@ tide_vi_mode_color_default 000000
 tide_vi_mode_color_insert 000000
 tide_vi_mode_color_replace 000000
 tide_vi_mode_color_visual 000000
+tide_zig_bg_color F7A41D
+tide_zig_color 000000

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -89,3 +89,5 @@ tide_vi_mode_icon_default D
 tide_vi_mode_icon_insert I
 tide_vi_mode_icon_replace R
 tide_vi_mode_icon_visual V
+tide_zig_bg_color yellow
+tide_zig_color black

--- a/functions/tide/configure/icons.fish
+++ b/functions/tide/configure/icons.fish
@@ -37,3 +37,4 @@ tide_vi_mode_icon_default D
 tide_vi_mode_icon_insert I
 tide_vi_mode_icon_replace R
 tide_vi_mode_icon_visual V
+tide_zig_icon 

--- a/tests/_tide_item_zig.test.fish
+++ b/tests/_tide_item_zig.test.fish
@@ -1,0 +1,22 @@
+# RUN: %fish %s
+_tide_parent_dirs
+
+function _zig
+    _tide_decolor (_tide_item_zig)
+end
+
+set -l zigDir (mktemp -d)
+cd $zigDir
+
+mock zig version "echo 0.11.0"
+set -lx tide_zig_icon 
+
+_zig # CHECK:
+
+touch build.zig
+_zig # CHECK:  0.11.0
+
+mock zig version "echo 0.12.0-dev.789+e6590fea1"
+_zig # CHECK:  0.12.0-dev
+
+command rm -r $zigDir


### PR DESCRIPTION
#### Description

This PR adds support for a Zig prompt item.

**Note:** I was unsure whether I needed to update the `tide_pwd_markers` variable.

#### How Has This Been Tested

I have added a test case that contains 3 test cases:
1. Being in a directory without a `build.zig` file should result in no item
1. Being in a directory with a `build.zig` and `zig version 0.11.0` should result in a prompt like: `ZIG_LOGO 0.11.0`
1. Being in a directory with a `build.zig` and `zig version 0.12.0-dev.789+e6590fea1` should result in a prompt like: `ZIG_LOGO 0.12.0-dev` so you know that your current version is a `dev` build

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**. (I have no access to a Mac so I cannot test this)

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [x] I am ready to update the wiki accordingly.
- [x] I have updated the tests accordingly.
