### PR TITLE
Add sudo prompt item

### DIFF
--- a/functions/_tide_item_sudo.fish
+++ b/functions/_tide_item_sudo.fish
@@ -1,0 +1,3 @@
+function _tide_item_sudo
+    sudo -n true &>/dev/null && _tide_print_item sudo $tide_sudo_icon
+end

--- a/functions/_tide_item_sudo.fish
+++ b/functions/_tide_item_sudo.fish
@@ -1,3 +1,4 @@
 function _tide_item_sudo
+    # note that calling `sudo -n` resets the sudo timer; as such, this item is disabled by default.
     sudo -n true &>/dev/null && _tide_print_item sudo $tide_sudo_icon
 end

--- a/functions/_tide_remove_unusable_items.fish
+++ b/functions/_tide_remove_unusable_items.fish
@@ -1,7 +1,7 @@
 function _tide_remove_unusable_items
     # Remove tool-specific items for tools the machine doesn't have installed
     set -l removed_items
-    for item in aws crystal direnv distrobox docker elixir gcloud git go java kubectl nix_shell node php pulumi python ruby rustc terraform toolbox zig
+    for item in aws crystal direnv distrobox docker elixir gcloud git go java kubectl nix_shell node php pulumi python ruby rustc sudo terraform toolbox zig
         contains $item $tide_left_prompt_items $tide_right_prompt_items || continue
 
         set -l cli_names $item

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -80,7 +80,7 @@ tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version
 tide_python_bg_color 444444
 tide_python_color 00AFAF
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration sudo context jobs direnv node python rustc java php pulumi ruby go gcloud kubectl distrobox toolbox terraform aws nix_shell crystal elixir zig
+tide_right_prompt_items status cmd_duration context jobs direnv node python rustc java php pulumi ruby go gcloud kubectl distrobox toolbox terraform aws nix_shell crystal elixir zig
 tide_right_prompt_prefix 
 tide_right_prompt_separator_diff_color 
 tide_right_prompt_separator_same_color 

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -80,7 +80,7 @@ tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version
 tide_python_bg_color 444444
 tide_python_color 00AFAF
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration context jobs direnv node python rustc java php pulumi ruby go gcloud kubectl distrobox toolbox terraform aws nix_shell crystal elixir zig
+tide_right_prompt_items status cmd_duration sudo context jobs direnv node python rustc java php pulumi ruby go gcloud kubectl distrobox toolbox terraform aws nix_shell crystal elixir zig
 tide_right_prompt_prefix 
 tide_right_prompt_separator_diff_color 
 tide_right_prompt_separator_same_color 
@@ -96,6 +96,8 @@ tide_status_bg_color 444444
 tide_status_bg_color_failure 444444
 tide_status_color $_tide_color_dark_green
 tide_status_color_failure D70000
+tide_sudo_bg_color 444444
+tide_sudo_color $_tide_color_gold
 tide_terraform_bg_color 444444
 tide_terraform_color 844FBA
 tide_time_bg_color 444444

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -71,6 +71,8 @@ tide_status_bg_color black
 tide_status_bg_color_failure black
 tide_status_color green
 tide_status_color_failure red
+tide_sudo_bg_color black
+tide_sudo_color bryellow
 tide_terraform_bg_color black
 tide_terraform_color magenta
 tide_time_bg_color black

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -80,7 +80,7 @@ tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version
 tide_python_bg_color normal
 tide_python_color 00AFAF
 tide_right_prompt_frame_enabled false
-tide_right_prompt_items status cmd_duration context jobs direnv node python rustc java php pulumi ruby go gcloud kubectl distrobox toolbox terraform aws nix_shell crystal elixir zig
+tide_right_prompt_items status cmd_duration sudo context jobs direnv node python rustc java php pulumi ruby go gcloud kubectl distrobox toolbox terraform aws nix_shell crystal elixir zig
 tide_right_prompt_prefix ' '
 tide_right_prompt_separator_diff_color ' '
 tide_right_prompt_separator_same_color ' '
@@ -96,6 +96,8 @@ tide_status_bg_color normal
 tide_status_bg_color_failure normal
 tide_status_color $_tide_color_dark_green
 tide_status_color_failure D70000
+tide_sudo_bg_color normal
+tide_sudo_color $_tide_color_gold
 tide_terraform_bg_color normal
 tide_terraform_color 844FBA
 tide_time_bg_color normal

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -80,7 +80,7 @@ tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version
 tide_python_bg_color normal
 tide_python_color 00AFAF
 tide_right_prompt_frame_enabled false
-tide_right_prompt_items status cmd_duration sudo context jobs direnv node python rustc java php pulumi ruby go gcloud kubectl distrobox toolbox terraform aws nix_shell crystal elixir zig
+tide_right_prompt_items status cmd_duration context jobs direnv node python rustc java php pulumi ruby go gcloud kubectl distrobox toolbox terraform aws nix_shell crystal elixir zig
 tide_right_prompt_prefix ' '
 tide_right_prompt_separator_diff_color ' '
 tide_right_prompt_separator_same_color ' '

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -71,6 +71,8 @@ tide_status_bg_color normal
 tide_status_bg_color_failure normal
 tide_status_color green
 tide_status_color_failure red
+tide_sudo_bg_color normal
+tide_sudo_color bryellow
 tide_terraform_bg_color normal
 tide_terraform_color magenta
 tide_time_bg_color normal

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -80,7 +80,7 @@ tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version
 tide_python_bg_color 444444
 tide_python_color 00AFAF
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration context jobs direnv node python rustc java php pulumi ruby go gcloud kubectl distrobox toolbox terraform aws nix_shell crystal elixir zig
+tide_right_prompt_items status cmd_duration sudo context jobs direnv node python rustc java php pulumi ruby go gcloud kubectl distrobox toolbox terraform aws nix_shell crystal elixir zig
 tide_right_prompt_prefix 
 tide_right_prompt_separator_diff_color 
 tide_right_prompt_separator_same_color 
@@ -96,6 +96,8 @@ tide_status_bg_color 2E3436
 tide_status_bg_color_failure CC0000
 tide_status_color 4E9A06
 tide_status_color_failure FFFF00
+tide_sudo_bg_color 444444
+tide_sudo_color $_tide_color_gold
 tide_terraform_bg_color 800080
 tide_terraform_color 000000
 tide_time_bg_color D3D7CF

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -80,7 +80,7 @@ tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version
 tide_python_bg_color 444444
 tide_python_color 00AFAF
 tide_right_prompt_frame_enabled true
-tide_right_prompt_items status cmd_duration sudo context jobs direnv node python rustc java php pulumi ruby go gcloud kubectl distrobox toolbox terraform aws nix_shell crystal elixir zig
+tide_right_prompt_items status cmd_duration context jobs direnv node python rustc java php pulumi ruby go gcloud kubectl distrobox toolbox terraform aws nix_shell crystal elixir zig
 tide_right_prompt_prefix 
 tide_right_prompt_separator_diff_color 
 tide_right_prompt_separator_same_color 

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -71,6 +71,8 @@ tide_status_bg_color black
 tide_status_bg_color_failure red
 tide_status_color green
 tide_status_color_failure bryellow
+tide_sudo_bg_color black
+tide_sudo_color bryellow
 tide_terraform_bg_color magenta
 tide_terraform_color black
 tide_time_bg_color white

--- a/functions/tide/configure/icons.fish
+++ b/functions/tide/configure/icons.fish
@@ -31,6 +31,7 @@ tide_rustc_icon 
 tide_shlvl_icon 
 tide_status_icon ✔
 tide_status_icon_failure ✘
+tide_sudo_icon 󰌋
 tide_terraform_icon
 tide_toolbox_icon 
 tide_vi_mode_icon_default D

--- a/tests/_tide_item_sudo.test.fish
+++ b/tests/_tide_item_sudo.test.fish
@@ -1,0 +1,9 @@
+# RUN: %fish %s
+_tide_parent_dirs
+
+mock sudo \* "return 1"
+_tide_decolor (_tide_item_sudo) # CHECK:
+
+mock sudo \* "return 0"
+set -g tide_sudo_icon 󰌋
+_tide_decolor (_tide_item_sudo) # CHECK: 󰌋


### PR DESCRIPTION
#### Description

Adds a simple prompt item that displays an icon if `sudo` can be called without a password. 

#### Motivation and Context

This is most useful in reminding the user that `sudo` has been called recently and hasn't timed out yet.

#### How Has This Been Tested

It correctly displays an icon when `sudo` can be called without a password, and displays nothing otherwise.

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

- [x] I am ready to update the wiki accordingly.
- [x] I have updated the tests accordingly.