### PR TITLE
Add job number display

### DIFF
--- a/functions/_tide_item_jobs.fish
+++ b/functions/_tide_item_jobs.fish
@@ -1,7 +1,7 @@
 function _tide_item_jobs
-    if test $_tide_jobs -gt $tide_jobs_threshold
+    set -q _tide_jobs && if test $_tide_jobs -ge $tide_jobs_number_threshold
         _tide_print_item jobs $tide_jobs_icon' ' $_tide_jobs
-    else if test $_tide_jobs -gt 0
+    else
         _tide_print_item jobs $tide_jobs_icon
     end
 end

--- a/functions/_tide_item_jobs.fish
+++ b/functions/_tide_item_jobs.fish
@@ -1,3 +1,7 @@
 function _tide_item_jobs
-    set -q _tide_jobs && _tide_print_item jobs $tide_jobs_icon
+    if test $_tide_jobs -gt $tide_jobs_threshold
+        _tide_print_item jobs $tide_jobs_icon' ' $_tide_jobs
+    else if test $_tide_jobs -gt 0
+        _tide_print_item jobs $tide_jobs_icon
+    end
 end

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -38,7 +38,7 @@ if contains newline $_tide_left_items # two line prompt initialization
         eval "
 function fish_prompt
     _tide_status=\$status _tide_pipestatus=\$pipestatus if not set -e _tide_repaint
-        set -lx _tide_jobs (count (jobs))
+        jobs -q && jobs -p | count | read -lx _tide_jobs
         $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
 set _tide_parent_dirs \$_tide_parent_dirs
 PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_2_line_prompt)\" &
@@ -66,7 +66,7 @@ end"
         eval "
 function fish_prompt
     _tide_status=\$status _tide_pipestatus=\$pipestatus if not set -e _tide_repaint
-        set -lx _tide_jobs (count (jobs))
+        jobs -q && jobs -p | count | read -lx _tide_jobs
         $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
 set _tide_parent_dirs \$_tide_parent_dirs
 PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_2_line_prompt)\" &
@@ -98,7 +98,7 @@ else # one line prompt initialization
 function fish_prompt
     set -lx _tide_status \$status
     _tide_pipestatus=\$pipestatus if not set -e _tide_repaint
-        set -lx _tide_jobs (count (jobs))
+        jobs -q && jobs -p | count | read -lx _tide_jobs
         $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
 set _tide_parent_dirs \$_tide_parent_dirs
 PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_1_line_prompt)\" &
@@ -125,7 +125,7 @@ end"
         eval "
 function fish_prompt
     _tide_status=\$status _tide_pipestatus=\$pipestatus if not set -e _tide_repaint
-        set -lx _tide_jobs (count (jobs))
+        jobs -q && jobs -p | count | read -lx _tide_jobs
         $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
 set _tide_parent_dirs \$_tide_parent_dirs
 PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_1_line_prompt)\" &

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -38,7 +38,7 @@ if contains newline $_tide_left_items # two line prompt initialization
         eval "
 function fish_prompt
     _tide_status=\$status _tide_pipestatus=\$pipestatus if not set -e _tide_repaint
-        jobs -q && set -lx _tide_jobs
+        set -lx _tide_jobs (count (jobs))
         $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
 set _tide_parent_dirs \$_tide_parent_dirs
 PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_2_line_prompt)\" &
@@ -66,7 +66,7 @@ end"
         eval "
 function fish_prompt
     _tide_status=\$status _tide_pipestatus=\$pipestatus if not set -e _tide_repaint
-        jobs -q && set -lx _tide_jobs
+        set -lx _tide_jobs (count (jobs))
         $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
 set _tide_parent_dirs \$_tide_parent_dirs
 PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_2_line_prompt)\" &
@@ -98,7 +98,7 @@ else # one line prompt initialization
 function fish_prompt
     set -lx _tide_status \$status
     _tide_pipestatus=\$pipestatus if not set -e _tide_repaint
-        jobs -q && set -lx _tide_jobs
+        set -lx _tide_jobs (count (jobs))
         $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
 set _tide_parent_dirs \$_tide_parent_dirs
 PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_1_line_prompt)\" &
@@ -125,7 +125,7 @@ end"
         eval "
 function fish_prompt
     _tide_status=\$status _tide_pipestatus=\$pipestatus if not set -e _tide_repaint
-        jobs -q && set -lx _tide_jobs
+        set -lx _tide_jobs (count (jobs))
         $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
 set _tide_parent_dirs \$_tide_parent_dirs
 PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_1_line_prompt)\" &

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -46,6 +46,7 @@ tide_java_bg_color 444444
 tide_java_color ED8B00
 tide_jobs_bg_color 444444
 tide_jobs_color $_tide_color_dark_green
+tide_jobs_threshold 1
 tide_kubectl_bg_color 444444
 tide_kubectl_color 326CE5
 tide_left_prompt_frame_enabled true

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -46,7 +46,7 @@ tide_java_bg_color 444444
 tide_java_color ED8B00
 tide_jobs_bg_color 444444
 tide_jobs_color $_tide_color_dark_green
-tide_jobs_threshold 1
+tide_jobs_number_threshold 1000
 tide_kubectl_bg_color 444444
 tide_kubectl_color 326CE5
 tide_left_prompt_frame_enabled true

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -46,6 +46,7 @@ tide_java_bg_color normal
 tide_java_color ED8B00
 tide_jobs_bg_color normal
 tide_jobs_color $_tide_color_dark_green
+tide_jobs_threshold 1
 tide_kubectl_bg_color normal
 tide_kubectl_color 326CE5
 tide_left_prompt_frame_enabled false

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -46,7 +46,7 @@ tide_java_bg_color normal
 tide_java_color ED8B00
 tide_jobs_bg_color normal
 tide_jobs_color $_tide_color_dark_green
-tide_jobs_threshold 1
+tide_jobs_number_threshold 1000
 tide_kubectl_bg_color normal
 tide_kubectl_color 326CE5
 tide_left_prompt_frame_enabled false

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -46,7 +46,7 @@ tide_java_bg_color ED8B00
 tide_java_color 000000
 tide_jobs_bg_color 444444
 tide_jobs_color 4E9A06
-tide_jobs_threshold 1
+tide_jobs_number_threshold 1000
 tide_kubectl_bg_color 326CE5
 tide_kubectl_color 000000
 tide_left_prompt_frame_enabled true

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -46,6 +46,7 @@ tide_java_bg_color ED8B00
 tide_java_color 000000
 tide_jobs_bg_color 444444
 tide_jobs_color 4E9A06
+tide_jobs_threshold 1
 tide_kubectl_bg_color 326CE5
 tide_kubectl_color 000000
 tide_left_prompt_frame_enabled true

--- a/tests/_tide_item_jobs.test.fish
+++ b/tests/_tide_item_jobs.test.fish
@@ -1,13 +1,14 @@
 # RUN: %fish %s
 _tide_parent_dirs
 
-set _tide_jobs 0
+set -lx tide_jobs_icon 
+set -lx tide_jobs_number_threshold 2
+
+set -e _tide_jobs
 _tide_decolor (_tide_item_jobs) # CHECK:
 
-set -lx tide_jobs_icon 
-set -lx tide_jobs_number_threshold 1000
-set _tide_jobs 1
+set -lx _tide_jobs 1
 _tide_decolor (_tide_item_jobs) # CHECK: 
 
-set _tide_jobs 2
+set -lx _tide_jobs 2
 _tide_decolor (_tide_item_jobs) # CHECK:  2

--- a/tests/_tide_item_jobs.test.fish
+++ b/tests/_tide_item_jobs.test.fish
@@ -1,9 +1,13 @@
 # RUN: %fish %s
 _tide_parent_dirs
 
-set -e _tide_jobs
+set _tide_jobs 0
 _tide_decolor (_tide_item_jobs) # CHECK:
 
 set -lx tide_jobs_icon 
-set -lx _tide_jobs
+set -lx tide_jobs_threshold 1
+set _tide_jobs 1
 _tide_decolor (_tide_item_jobs) # CHECK: 
+
+set _tide_jobs 2
+_tide_decolor (_tide_item_jobs) # CHECK:  2

--- a/tests/_tide_item_jobs.test.fish
+++ b/tests/_tide_item_jobs.test.fish
@@ -5,7 +5,7 @@ set _tide_jobs 0
 _tide_decolor (_tide_item_jobs) # CHECK:
 
 set -lx tide_jobs_icon 
-set -lx tide_jobs_threshold 1
+set -lx tide_jobs_number_threshold 1000
 set _tide_jobs 1
 _tide_decolor (_tide_item_jobs) # CHECK: 
 


### PR DESCRIPTION
#### Description

Prints the number of jobs running if it exceeds a certain threshold (`tide_jobs_threshold`). By default, this threshold is 1.

#### How Has This Been Tested

- [x] I have tested using **Linux**.
- [x] I have tested using **MacOS**.

#### Checklist

- [x] I am ready to update the wiki accordingly.
- [x] I have updated the tests accordingly.
