### PR TITLE
Fix `_tide_pwd` when the user's `HOME` contains spaces.

### DIFF
--- a/functions/_tide_pwd.fish
+++ b/functions/_tide_pwd.fish
@@ -18,7 +18,7 @@ eval "function _tide_pwd
     string join / -- \$split_output | string length -V | read -g _tide_pwd_len
 
     i=1 for dir_section in \$split_pwd[2..-2]
-        string join -- / \$split_pwd[..\$i] | string replace '~' $HOME | read -l parent_dir # Uses i before increment
+        string join -- / \$split_pwd[..\$i] | string replace '~' \"$HOME\" | read -l parent_dir # Uses i before increment
 
         math \$i+1 | read i
 


### PR DESCRIPTION
On my Windows system, for whatever reason, my `HOME` is `C:\Users\Alex Rønne Petersen` rather than the usual `C:\Users\alex` kind of thing you'd expect. (And yes, this has found a great many bugs in various pieces of software. 😄)

This would lead to more and more errors the deeper into a directory I went:

```
❯ cd /z
❯ cd Source
string replace: too many arguments
❯ cd tests
string replace: too many arguments
string replace: too many arguments
❯ cd cs
string replace: too many arguments
string replace: too many arguments
string replace: too many arguments
❯ cd bin
string replace: too many arguments
string replace: too many arguments
string replace: too many arguments
string replace: too many arguments
```

Quoting the use of `$HOME` here fixes the issue.

<!-- Provide a general summary of your changes in the Title above. -->

#### Description

<!-- Describe your changes. -->

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Closes # <!--- Please link to an open issue. -->

#### Screenshots (if appropriate)

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [ ] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [x] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.
