### PR TITLE
Handle virtualenv names without `-`

### DIFF
--- a/functions/_tide_item_python.fish
+++ b/functions/_tide_item_python.fish
@@ -9,7 +9,7 @@ function _tide_item_python
         # pipenv $VIRTUAL_ENV looks like /home/ilan/.local/share/virtualenvs/pipenv_project-EwRYuc3l
         # Detect whether we are using pipenv by looking for 'virtualenvs'. If so, remove the hash at the end.
         if test "$dir" = virtualenvs
-            string match -qr "(?<base>.*)-.*" $base
+            string match -qr "(?<base>[^/-]*)" $base
             _tide_print_item python $tide_python_icon' ' "$v ($base)"
         else if contains -- "$base" virtualenv venv .venv env # avoid generic names
             _tide_print_item python $tide_python_icon' ' "$v ($dir)"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Description

I have all my virtual env names without dashes. This attempts to handle that in order to properly display the virtualenv name.


<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### Motivation and Context

Can't see the virtualenv name

<!-- Why is this change required? What problem does it solve? -->

Closes #497

#### Screenshots (if appropriate)

<img width="864" alt="Screenshot 2024-03-16 at 21 14 41" src="https://github.com/IlanCosman/tide/assets/10972027/9cf698ce-ae05-4bf3-b169-7d472c90b69f">




#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [ ] I have tested using **Linux**.
- [x] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [x] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.
