### PR TITLE
 Add icons for git item

### DIFF
--- a/functions/_tide_item_git.fish
+++ b/functions/_tide_item_git.fish
@@ -61,8 +61,17 @@ function _tide_item_git
         set -g tide_git_bg_color $tide_git_bg_color_unstable
     end
 
+    # Icon for github if remote is set as github.com
+    if git remote -v | grep "git@github.com" >/dev/null
+        set -g tide_git_remote_icon "  "
+    else if test $(git remote -v | wc -l) -eq 0
+        set -g tide_git_remote_icon " 󰅛 "
+    else
+        set -g tide_git_remote_icon ""
+    end
+
     if set -q tide_git_icon_true
-        _tide_print_item git $_tide_location_color$tide_git_icon' ' (set_color white; echo -ns $location $tide_git_icon_spacer
+        _tide_print_item git $_tide_location_color$tide_git_remote_icon$tide_git_icon' ' (set_color white; echo -ns $location $tide_git_icon_spacer
             set_color $tide_git_color_operation; echo -ns ' '$operation ' '$step/$total_steps
             set_color $tide_git_color_upstream; echo -ns $tide_git_icon_upstream_behind$behind tide_git_icon_upstream_ahead$ahead
             set_color $tide_git_color_stash; echo -ns $tide_git_icon_stash$stash

--- a/functions/_tide_item_git.fish
+++ b/functions/_tide_item_git.fish
@@ -61,12 +61,23 @@ function _tide_item_git
         set -g tide_git_bg_color $tide_git_bg_color_unstable
     end
 
-    _tide_print_item git $_tide_location_color$tide_git_icon' ' (set_color white; echo -ns $location
-        set_color $tide_git_color_operation; echo -ns ' '$operation ' '$step/$total_steps
-        set_color $tide_git_color_upstream; echo -ns ' ⇣'$behind ' ⇡'$ahead
-        set_color $tide_git_color_stash; echo -ns ' *'$stash
-        set_color $tide_git_color_conflicted; echo -ns ' ~'$conflicted
-        set_color $tide_git_color_staged; echo -ns ' +'$staged
-        set_color $tide_git_color_dirty; echo -ns ' !'$dirty
-        set_color $tide_git_color_untracked; echo -ns ' ?'$untracked)
+    if set -q tide_git_icon_true
+        _tide_print_item git $_tide_location_color$tide_git_icon' ' (set_color white; echo -ns $location $tide_git_icon_spacer
+            set_color $tide_git_color_operation; echo -ns ' '$operation ' '$step/$total_steps
+            set_color $tide_git_color_upstream; echo -ns $tide_git_icon_upstream_behind$behind tide_git_icon_upstream_ahead$ahead
+            set_color $tide_git_color_stash; echo -ns $tide_git_icon_stash$stash
+            set_color $tide_git_color_conflicted; echo -ns $tide_git_icon_conflicted$conflicted
+            set_color $tide_git_color_staged; echo -ns $tide_git_icon_staged$staged
+            set_color $tide_git_color_dirty; echo -ns $tide_git_icon_dirty$dirty
+            set_color $tide_git_color_untracked; echo -ns $tide_git_icon_untracked$untracked)
+    else
+        _tide_print_item git $_tide_location_color$tide_git_icon' ' (set_color white; echo -ns $location
+            set_color $tide_git_color_operation; echo -ns ' '$operation ' '$step/$total_steps
+            set_color $tide_git_color_upstream; echo -ns ' ⇣'$behind ' ⇡'$ahead
+            set_color $tide_git_color_stash; echo -ns ' *'$stash
+            set_color $tide_git_color_conflicted; echo -ns ' ~'$conflicted
+            set_color $tide_git_color_staged; echo -ns ' +'$staged
+            set_color $tide_git_color_dirty; echo -ns ' !'$dirty
+            set_color $tide_git_color_untracked; echo -ns ' ?'$untracked)
+    end
 end

--- a/functions/tide/configure/choices/all/icons.fish
+++ b/functions/tide/configure/choices/all/icons.fish
@@ -22,12 +22,30 @@ function _enable_icons
     set -g fake_tide_pwd_icon_home 
     set -g fake_tide_cmd_duration_icon 
     set -g fake_tide_git_icon 
+    set -g fake_tide_git_icon_true true
+    set -g fake_tide_git_icon_spacer ''
+    set -g fake_tide_git_icon_upstream_behind ⇣
+    set -g fake_tide_git_icon_upstream_ahead ⇡
+    set -g fake_tide_git_icon_stash ' 󱉰 '
+    set -g fake_tide_git_icon_conflicted '  '
+    set -g fake_tide_git_icon_staged '  '
+    set -g fake_tide_git_icon_dirty '  '
+    set -g fake_tide_git_icon_untracked ' 󰩌 '
 end
 
 function _disable_icons
     _tide_find_and_remove os fake_tide_left_prompt_items
-    set fake_tide_pwd_icon
-    set fake_tide_pwd_icon_home
-    set fake_tide_cmd_duration_icon
-    set fake_tide_git_icon
+    set -g fake_tide_pwd_icon
+    set -g fake_tide_pwd_icon_home
+    set -g fake_tide_cmd_duration_icon
+    set -g fake_tide_git_icon
+    set -e fake_tide_git_icon_true
+    set -g fake_tide_git_icon_spacer ' '
+    set -g fake_tide_git_icon_upstream_behind ⇣
+    set -g fake_tide_git_icon_upstream_ahead ⇡
+    set -g fake_tide_git_icon_stash ' *'
+    set -g fake_tide_git_icon_conflicted ' ~'
+    set -g fake_tide_git_icon_staged ' +'
+    set -g fake_tide_git_icon_dirty ' !'
+    set -g fake_tide_git_icon_untracked ' ?'
 end

--- a/functions/tide/configure/icons.fish
+++ b/functions/tide/configure/icons.fish
@@ -12,6 +12,13 @@ tide_docker_icon 
 tide_elixir_icon 
 tide_gcloud_icon 󰊭 # Actual google cloud glyph is harder to see
 tide_git_icon
+tide_git_icon_upstream_behind ⇣
+tide_git_icon_upstream_ahead ⇡
+tide_git_icon_stash 󱉰
+tide_git_icon_conflicted 
+tide_git_icon_staged 
+tide_git_icon_dirty 
+tide_git_icon_untracked 󰩌
 tide_go_icon 
 tide_java_icon 
 tide_jobs_icon 


### PR DESCRIPTION
Add the possibility to enable and disable git icons for repository status.

<!-- Provide a general summary of your changes in the Title above. -->

#### Description

Wanted icons for gits that can be changed with variables.

<!-- Describe your changes. -->
- add space before icon so they are not small
- fix icon enabling and disabling with appropriate spacing if needed
- will change style on tide configure re-run
<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

Icons can be changed by changing following variables : 
```
tide_git_icon
tide_git_icon_conflicted
tide_git_icon_dirty 
tide_git_icon_spacer
tide_git_icon_staged 
tide_git_icon_stash 
tide_git_icon_untracked 
tide_git_icon_upstream_ahead
tide_git_icon_upstream_behind
```

#### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

This is to enable replacing `*  ~ + ! ?` with nerd fonts symbols `󱉰     󰩌`
**Note: Open to other symbols !**

Closes #349 <!--- Please link to an open issue. -->
Edit: Closes #239 
#### Screenshots (if appropriate)
![image](https://github.com/IlanCosman/tide/assets/5272079/1d3ee2ea-97cc-49ad-9152-4eea9d005666)
Edit: no remote defined or github.com icon if remote is set to `git@github.com`
![image](https://github.com/IlanCosman/tide/assets/5272079/832c44ed-707f-4e0a-b42a-11c47ec148f4)

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.
