### PR TITLE
Replace icons with equivalents better supported by intellij terminal

### DIFF
--- a/functions/tide/configure/icons.fish
+++ b/functions/tide/configure/icons.fish
@@ -15,7 +15,7 @@ tide_git_icon
 tide_go_icon 
 tide_java_icon 
 tide_jobs_icon 
-tide_kubectl_icon 󱃾
+tide_kubectl_icon ⎈
 tide_nix_shell_icon 
 tide_node_icon  # Actual nodejs glyph is harder to see
 tide_os_icon $os_branding_icon
@@ -26,7 +26,7 @@ tide_pulumi_icon 
 tide_pwd_icon
 tide_pwd_icon_home
 tide_pwd_icon_unwritable 
-tide_python_icon 󰌠
+tide_python_icon 
 tide_ruby_icon 
 tide_rustc_icon 
 tide_shlvl_icon 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Description

<!-- Describe your changes. -->
The existing icons are not supported by intellij and cause weird line break issues. The new icons work when manually configured:

![image](https://github.com/user-attachments/assets/53329d42-539d-4f27-927a-f41b13e49b94)

After this PR this manual configuration should no longe rbe necessary.

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Closes #476 <!--- Please link to an open issue. -->

#### Screenshots (if appropriate)

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

I ran this: 
fisher remove ilancosman/tide@v6
fisher install StefanLobbenmeierObjego/tide@patch-1
Then reconfigured, enabled "Show many Icons":
`tide configure --auto --style=Lean --prompt_colors='True color' --show_time='24-hour format' --lean_prompt_height='One line' --prompt_spacing=Compact --icons='Many icons' --transient=No`


- [x] I have tested using **Linux**. (https://github.com/IlanCosman/tide/issues/476#issuecomment-2252066594)
- [x] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.
