### PR TITLE
add guix item

### DIFF
--- a/functions/_tide_item_guix.fish
+++ b/functions/_tide_item_guix.fish
@@ -1,0 +1,5 @@
+function _tide_item_guix
+    if test -n "$GUIX_ENVIRONMENT"
+        _tide_print_item guix $tide_guix_icon'' "[GUIX ENV]"
+    end
+end

--- a/functions/_tide_remove_unusable_items.fish
+++ b/functions/_tide_remove_unusable_items.fish
@@ -1,7 +1,7 @@
 function _tide_remove_unusable_items
     # Remove tool-specific items for tools the machine doesn't have installed
     set -l removed_items
-    for item in aws bun crystal direnv distrobox docker elixir gcloud git go java kubectl nix_shell node php pulumi python ruby rustc terraform toolbox zig
+    for item in aws bun crystal direnv distrobox docker elixir gcloud git go java kubectl nix_shell node php pulumi python ruby rustc terraform toolbox zig guix
         contains $item $tide_left_prompt_items $tide_right_prompt_items || continue
 
         set -l cli_names $item
@@ -12,6 +12,8 @@ function _tide_remove_unusable_items
                 set cli_names nix nix-shell
             case python
                 set cli_names python python3
+            case guix
+                set cli_names guix
         end
         type --query $cli_names || set -a removed_items $item
     end

--- a/tests/_tide_item_guix_shell.test.fish
+++ b/tests/_tide_item_guix_shell.test.fish
@@ -1,0 +1,13 @@
+# RUN: %fish %s
+_tide_parent_dirs
+
+function _guix_shell
+    _tide_decolor (_tide_item_guix)
+end
+
+
+_guix_shell # CHECK:
+
+set -x GUIX_ENVIRONMENT "/gnu/store/test"
+
+_guix_shell # CHECK: [GUIX ENV]


### PR DESCRIPTION
#### Description

Adds the guix shell item, which checks if GUIX_ENVIRONMENT is defined, and lets users know they are in an env. 

#### Motivation and Context

Similar to nix, it's useful to know when you are in an environment

#### How Has This Been Tested

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

- [ ] I am ready to update the wiki accordingly.
- [x] I have updated the tests accordingly.
