### PR TITLE
fixing the `--short-version` glitches

### DIFF
--- a/functions/_tide_item_elixir.fish
+++ b/functions/_tide_item_elixir.fish
@@ -1,4 +1,4 @@
 function _tide_item_elixir
     path is $_tide_parent_dirs/mix.exs &&
-        _tide_print_item elixir $tide_elixir_icon' ' (elixir --short-version)
+        _tide_print_item elixir $tide_elixir_icon' ' (elixir --short-version 2> /dev/null)
 end


### PR DESCRIPTION
This fixes the `--short-version` glitches referenced in issue https://github.com/IlanCosman/tide/issues/526

#### Description

Redirecting errors on `elixir --short-version` to `/dev/null` seems to fix the problem on my machines I've tested on.


#### Motivation and Context

Closes https://github.com/IlanCosman/tide/issues/526 (see for more details)


#### How Has This Been Tested

- [x] I have tested using **Linux**.
- [x] I have tested using **MacOS**.

Adding the `2> /dev/null` redirection on both platforms makes the glitch disappears: no more unrequired additional new line added after the prompt, sometimes interrupting a command being typed nor `--short-version : Unknown option` error being haphazardly displayed.


#### Checklist

- [ ] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.

Sorry, I don't know quite how to write tests for fish scripting, especially how to address such a glitch. As for the wiki, this being a bug fix, I'm not sure there needs to be an update? Let me know 🙂 
