### PR TITLE
Add fade options for promt heads and tails

### DIFF
--- a/functions/tide/configure/choices/powerline/powerline_prompt_heads.fish
+++ b/functions/tide/configure/choices/powerline/powerline_prompt_heads.fish
@@ -16,6 +16,11 @@ function powerline_prompt_heads
     set -g fake_tide_right_prompt_prefix 
     _tide_display_prompt
 
+    _tide_option 4 Fade
+    set -g fake_tide_left_prompt_suffix ▓▒░
+    set -g fake_tide_right_prompt_prefix ░▒▓
+    _tide_display_prompt
+
     _tide_menu (status function)
     switch $_tide_selected_option
         case Sharp
@@ -27,6 +32,9 @@ function powerline_prompt_heads
         case Round
             set -g fake_tide_left_prompt_suffix 
             set -g fake_tide_right_prompt_prefix 
+        case Fade
+            set -g fake_tide_left_prompt_suffix ▓▒░
+            set -g fake_tide_right_prompt_prefix ░▒▓
     end
     _next_choice powerline/powerline_prompt_tails
 end

--- a/functions/tide/configure/choices/powerline/powerline_prompt_tails.fish
+++ b/functions/tide/configure/choices/powerline/powerline_prompt_tails.fish
@@ -21,6 +21,11 @@ function powerline_prompt_tails
     set -g fake_tide_right_prompt_suffix 
     _tide_display_prompt
 
+    _tide_option 5 Fade
+    set -g fake_tide_left_prompt_prefix ░▒▓
+    set -g fake_tide_right_prompt_suffix ▓▒░
+    _tide_display_prompt
+
     _tide_menu (status function)
     switch $_tide_selected_option
         case Flat
@@ -35,6 +40,9 @@ function powerline_prompt_tails
         case Round
             set -g fake_tide_left_prompt_prefix 
             set -g fake_tide_right_prompt_suffix 
+        case Fade
+            set -g fake_tide_left_prompt_prefix ░▒▓
+            set -g fake_tide_right_prompt_suffix ▓▒░
     end
     _next_choice powerline/powerline_prompt_style
 end


### PR DESCRIPTION
#### Description

This adds the configuration options for using fade for prompt heads and tails.

#### Motivation and Context

[powerlevel10k](https://github.com/romkatv/powerlevel10k) has a [fade](https://github.com/romkatv/powerlevel10k/blob/d71edb83f9c7f045a0d528eeff3445ec3d518d71/internal/wizard.zsh#L42-L43) option which I really like, but my primary shell is fish.

#### Screenshots (if appropriate)

##### Tail:
<img width="606" alt="image" src="https://github.com/user-attachments/assets/b1dfbc4c-685d-4615-94ad-1ff196044cf9">

##### Head:
<img width="727" alt="image" src="https://github.com/user-attachments/assets/a0bde9cb-9e45-4a10-be0c-8e924a5996c7">

#### How Has This Been Tested

1. Created a fork of tide
2. Cloned fork locally
3. Uninstalled tide with fisher `fisher remove fisher remove ilancosman/tide@v6`
4. Installed local tide clone with `fisher install .`
5. Went through `tide configure`

- [x] I have tested using **Linux**.
- [x] I have tested using **MacOS**.

#### Checklist

- [x] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.
