### PR TITLE
Bug Fix Array Element Removal in _tide_pwd.fish

### DIFF
--- a/functions/_tide_pwd.fish
+++ b/functions/_tide_pwd.fish
@@ -28,8 +28,10 @@ eval "function _tide_pwd
             string match -qr \"(?<trunc>\..|.)\" \$dir_section
 
             set -l glob \$parent_dir/\$trunc*/
-            set -e glob[(contains -i \$parent_dir/\$dir_section/ \$glob)] # This is faster than inverse string match
-
+            set -l indices (contains -i $parent_dir/$dir_section/ $glob)
+            if set -q indices[1]
+                set -e glob[$indices]
+            end
             while string match -qr \"^\$parent_dir/\$(string escape --style=regex \$trunc)\" \$glob &&
                     string match -qr \"(?<trunc>\$(string escape --style=regex \$trunc).)\" \$dir_section
             end


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Description

This pull request addresses an error occurring in the Fish shell prompt function _tide_pwd.fish. The original line of code attempts to remove an element from the glob array using an incorrect approach involving the contains command. When the list is empty this code shows error:

```shell
~/.config/fish/functions/_tide_pwd.fish (line 23):
            set -e glob[(contains -i $parent_dir/$dir_section/ $glob)] # This is faster than inverse string match
            ^
in function '_tide_pwd'
in command substitution
in command substitution
in function '__fish_prompt_orig'
	called on line 47 of file -
in function 'fish_prompt'
in command substitution
```

So I fixed this line of code to handle empty list situation.

<!-- Describe your changes. -->

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Closes # <!--- Please link to an open issue. -->

#### Screenshots (if appropriate)

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [ ] I have tested using **Linux**.
- [x] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.
