### PR TITLE
which kubectl

### DIFF
--- a/functions/_tide_item_kubectl.fish
+++ b/functions/_tide_item_kubectl.fish
@@ -1,4 +1,4 @@
 function _tide_item_kubectl
-    kubectl config view --minify --output 'jsonpath={.current-context}/{..namespace}' 2>/dev/null | read -l context &&
+    which kubectl 2>/dev/null && kubectl config view --minify --output 'jsonpath={.current-context}/{..namespace}' 2>/dev/null | read -l context &&
         _tide_print_item kubectl $tide_kubectl_icon' ' (string replace -r '/(|default)$' '' $context)
 end


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Description

Prevent trying to execute `kubectl` if not available. This is what fixed it for me.

<!-- Describe your changes. -->

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### Motivation and Context

I keep seeing this error when using Tide:

```
fish: Unknown command: kubectl
~/.config/fish/functions/_tide_item_kubectl.fish (line 2):
    kubectl config view --minify --output 'jsonpath={.current-context}/{..namespace}' 2>/dev/null | read -l context &&
    ^~~~~~^
in function '_tide_item_kubectl'
        called on line 15 of file ~/.config/fish/functions/_tide_2_line_prompt.fish
in function '_tide_2_line_prompt'
in command substitution
```

<!-- Why is this change required? What problem does it solve? -->

Closes # <!--- Please link to an open issue. -->

#### Screenshots (if appropriate)

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [X] I have tested using **Windows (MSYS2 MINGW64)**
- [ ] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.
