### PR TITLE
Add rosetta item when running translated

### DIFF
--- a/functions/_tide_item_rosetta.fish
+++ b/functions/_tide_item_rosetta.fish
@@ -1,0 +1,6 @@
+function _tide_item_rosetta
+    if test (sysctl -ne sysctl.proc_translated) = 1
+        set machine (uname -m)
+        _tide_print_item rosetta $tide_rosetta_icon' ' $machine
+    end
+end

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -1,3 +1,5 @@
+tide_rosetta_bg_color 444444
+tide_rosetta_color BE7A14
 tide_aws_bg_color 444444
 tide_aws_color FF9900
 tide_bun_bg_color 14151A

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -1,3 +1,5 @@
+tide_rosetta_bg_color black
+tide_rosetta_color bryellow
 tide_aws_bg_color black
 tide_aws_color yellow
 tide_bun_bg_color black

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -1,3 +1,5 @@
+tide_rosetta_bg_color normal
+tide_rosetta_color DC5D12
 tide_aws_bg_color normal
 tide_aws_color FF9900
 tide_bun_bg_color normal

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -1,3 +1,5 @@
+tide_rosetta_bg_color normal
+tide_rosetta_color bryellow
 tide_aws_bg_color normal
 tide_aws_color yellow
 tide_bun_bg_color normal

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -1,3 +1,5 @@
+tide_rosetta_bg_color DC5D12
+tide_rosetta_color 000000
 tide_aws_bg_color FF9900
 tide_aws_color 232F3E
 tide_bun_bg_color FBF0DF

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -1,3 +1,5 @@
+tide_rosetta_bg_color bryellow
+tide_rosetta_color brblack
 tide_aws_bg_color yellow
 tide_aws_color brblack
 tide_bun_bg_color white

--- a/functions/tide/configure/icons.fish
+++ b/functions/tide/configure/icons.fish
@@ -1,3 +1,4 @@
+tide_rosetta_icon 
 tide_aws_icon  # Actual aws glyph is harder to see
 tide_bun_icon 󰳓
 tide_character_icon ❯


### PR DESCRIPTION
#### Description

This adds a rosetta item. When added to the prompt, it checks if running we are running translated (x86_64 emulation on arm64 on Apple Silicon).

It'll show ` x86_64` when added and running translated.

#### Motivation and Context

When looking into [game porting toolkit](https://www.applegamingwiki.com/wiki/Game_Porting_Toolkit#Homebrew), there is an optional guide of having both x86 and arm64 [homebrew](https://brew.sh) installed.

When running fish using:

```sh
arch -x86_64 /usr/bin/local/fish
```

It doesn't have a visual indicator by default that you're not in native fish.

#### Screenshots (if appropriate)

When using `set --prepend tide_left_prompt_items rosetta` with base16 colors translated:
![terminal has x86_64 shown when running fish in rosetta](https://github.com/user-attachments/assets/7d724232-df54-4f76-bdd1-1767c5ad3822)

Not translated:
![terminal has no indicator when running native](https://github.com/user-attachments/assets/b9101415-22bd-498c-949e-c346b6856bef)


#### How Has This Been Tested

Tested locally on macOS. This is not intended to be used with Linux, but could be adapted to do so.

- [ ] I have tested using **Linux**.
- [x] I have tested using **MacOS**.

#### Checklist

- [x] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.
