### PR TITLE
Fix an error when Python is not installed

### DIFF
--- a/functions/_tide_item_python.fish
+++ b/functions/_tide_item_python.fish
@@ -2,9 +2,11 @@ function _tide_item_python
     if test -n "$VIRTUAL_ENV"
         if command -q python3
             python3 --version | string match -qr "(?<v>[\d.]+)"
-        else
+        else if command -q python
             python --version | string match -qr "(?<v>[\d.]+)"
-        end
+	else
+	   return
+	end
         string match -qr "^.*/(?<dir>.*)/(?<base>.*)" $VIRTUAL_ENV
         # pipenv $VIRTUAL_ENV looks like /home/ilan/.local/share/virtualenvs/pipenv_project-EwRYuc3l
         # Detect whether we are using pipenv by looking for 'virtualenvs'. If so, remove the hash at the end.
@@ -19,8 +21,10 @@ function _tide_item_python
     else if path is .python-version Pipfile __init__.py pyproject.toml requirements.txt setup.py
         if command -q python3
             python3 --version | string match -qr "(?<v>[\d.]+)"
-        else
+        else if command -q python
             python --version | string match -qr "(?<v>[\d.]+)"
+	else
+	   return
         end
         _tide_print_item python $tide_python_icon' ' $v
     end

--- a/functions/_tide_item_python.fish
+++ b/functions/_tide_item_python.fish
@@ -4,9 +4,9 @@ function _tide_item_python
             python3 --version | string match -qr "(?<v>[\d.]+)"
         else if command -q python
             python --version | string match -qr "(?<v>[\d.]+)"
-	else
-	   return
-	end
+        else
+            return
+        end
         string match -qr "^.*/(?<dir>.*)/(?<base>.*)" $VIRTUAL_ENV
         # pipenv $VIRTUAL_ENV looks like /home/ilan/.local/share/virtualenvs/pipenv_project-EwRYuc3l
         # Detect whether we are using pipenv by looking for 'virtualenvs'. If so, remove the hash at the end.
@@ -23,8 +23,8 @@ function _tide_item_python
             python3 --version | string match -qr "(?<v>[\d.]+)"
         else if command -q python
             python --version | string match -qr "(?<v>[\d.]+)"
-	else
-	   return
+        else
+            return
         end
         _tide_print_item python $tide_python_icon' ' $v
     end


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Description

<!-- Describe your changes. -->

I'm using a dev-container setup with distrobox, with everything besides the OS shared between the container and the host system. Python is not installed on the host system, but it is installed in the container. All vars are shared between the system and the container, so the host thinks that it is in the python environment, while the environment is not installed. 

This fix shows nothing if there is no python available.

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Shows error if VIRTUAL_ENV is well-defined, but python is not there.

Closes # <!--- Please link to an open issue. -->

#### Screenshots (if appropriate)

#### How Has This Been Tested

Just checked on my machine; the change is trivial, so I don't think it needs heavy testing..

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [x] I am ready to update the wiki accordingly. (not relevant)
- [ ] I have updated the tests accordingly.
