### PR TITLE
fix: restore path based parsing in 4.0

### DIFF
--- a/functions/_tide_parent_dirs.fish
+++ b/functions/_tide_parent_dirs.fish
@@ -1,7 +1,11 @@
 function _tide_parent_dirs --on-variable PWD
-    set -g _tide_parent_dirs (string escape (
-        for dir in (string split / -- $PWD)
-            set -la parts $dir
-            string join / -- $parts
-        end))
+    set -g _tide_parent_dirs (
+        string escape (
+            for dir in (string split / -- $PWD)
+                if test (string length \"$dir\") -lt 1
+                    continue
+                end
+                set -a parts $dir
+                string join "" (string join / --  $parts) ""
+            end))
 end

--- a/functions/_tide_parent_dirs.fish
+++ b/functions/_tide_parent_dirs.fish
@@ -2,11 +2,8 @@ function _tide_parent_dirs --on-variable PWD
     set -g _tide_parent_dirs (
         string escape (
             for dir in (string split / -- $PWD)
-                if test (string length \"$dir\") -lt 1
-                    continue
-                end
                 set -fa parts $dir
-                string join "" (string join / --  $parts) ""
+                string join / -- $parts
             end
         )
     )

--- a/functions/_tide_parent_dirs.fish
+++ b/functions/_tide_parent_dirs.fish
@@ -5,7 +5,7 @@ function _tide_parent_dirs --on-variable PWD
                 if test (string length \"$dir\") -lt 1
                     continue
                 end
-                set -a parts $dir
+                set -fa parts $dir
                 string join "" (string join / --  $parts) ""
             end))
 end

--- a/functions/_tide_parent_dirs.fish
+++ b/functions/_tide_parent_dirs.fish
@@ -7,5 +7,7 @@ function _tide_parent_dirs --on-variable PWD
                 end
                 set -fa parts $dir
                 string join "" (string join / --  $parts) ""
-            end))
+            end
+        )
+    )
 end


### PR DESCRIPTION
This fixes issue 564, where empty directories are returned after upgrading to 4.0.0. This also safely wraps paths.

#### Description

Restore path based parsing for a variety of _tide_item functions. 

#### Motivation and Context

When a user changes directory into a one that contains, lets say package.json, tide normally picks up the version and prints it on the status line. This stopped working when fish moved to 4.0.0. This restores the previous behavior by checking for directories that are invalid (zero length) and safely wrapping the directories with quotes.

Closes https://github.com/IlanCosman/tide/issues/564

#### Screenshots (if appropriate)

#### How Has This Been Tested

I ran this against the make commands list in contributing.

- [X] I have tested using **Linux**. [fish 3.7.1] [nixos]
- [X] I have tested using **MacOS**. [fish 3.7.1] [fish 4.0.0] [MacOS Sequoia 15.3.1]

#### Checklist

- [X] I am ready to update the wiki accordingly. **no changes needed**
- [X] I have updated the tests accordingly. **no changes needed**
