### PR TITLE
Pass variables to subshells explicitly to avoid polluting global environment variables

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,8 +3,6 @@ name: CI
 
 on:
   push:
-    branches-ignore:
-      - main
     tags-ignore:
       - v.*
   pull_request:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,10 +8,11 @@ on:
     tags-ignore:
       - v.*
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
       - uses: fish-actions/install-fish@v1

--- a/functions/_tide_cache_variables.fish
+++ b/functions/_tide_cache_variables.fish
@@ -1,17 +1,17 @@
 function _tide_cache_variables
     # Same-color-separator color
-    set_color $tide_prompt_color_separator_same_color | read -gx _tide_color_separator_same_color
+    set_color $tide_prompt_color_separator_same_color | read -g _tide_color_separator_same_color
 
     # git
-    contains git $_tide_left_items $_tide_right_items && set_color $tide_git_color_branch | read -gx _tide_location_color
+    contains git $_tide_left_items $_tide_right_items && set_color $tide_git_color_branch | read -g _tide_location_color
 
     # private_mode
     if contains private_mode $_tide_left_items $_tide_right_items && test -n "$fish_private_mode"
-        set -gx _tide_private_mode
+        set -g _tide_private_mode true
     else
         set -e _tide_private_mode
     end
 
     # item padding
-    test "$tide_prompt_pad_items" = true && set -gx _tide_pad ' ' || set -e _tide_pad
+    test "$tide_prompt_pad_items" = true && set -g _tide_pad ' ' || set -e _tide_pad
 end

--- a/functions/_tide_item_private_mode.fish
+++ b/functions/_tide_item_private_mode.fish
@@ -1,3 +1,3 @@
 function _tide_item_private_mode
-    set -q _tide_private_mode && _tide_print_item private_mode $tide_private_mode_icon
+    test $_tide_private_mode = true; and _tide_print_item private_mode $tide_private_mode_icon
 end

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -41,6 +41,7 @@ function fish_prompt
         jobs -q && jobs -p | count | read -lx _tide_jobs
         $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
 set _tide_parent_dirs \$_tide_parent_dirs
+_tide_cache_variables
 PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_2_line_prompt)\" &
         builtin disown
 
@@ -69,6 +70,7 @@ function fish_prompt
         jobs -q && jobs -p | count | read -lx _tide_jobs
         $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
 set _tide_parent_dirs \$_tide_parent_dirs
+_tide_cache_variables
 PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_2_line_prompt)\" &
         builtin disown
 
@@ -101,6 +103,7 @@ function fish_prompt
         jobs -q && jobs -p | count | read -lx _tide_jobs
         $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
 set _tide_parent_dirs \$_tide_parent_dirs
+_tide_cache_variables
 PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_1_line_prompt)\" &
         builtin disown
 
@@ -128,6 +131,7 @@ function fish_prompt
         jobs -q && jobs -p | count | read -lx _tide_jobs
         $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
 set _tide_parent_dirs \$_tide_parent_dirs
+_tide_cache_variables
 PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_1_line_prompt)\" &
         builtin disown
 

--- a/functions/tide/configure/functions/_fake_tide_cache_variables.fish
+++ b/functions/tide/configure/functions/_fake_tide_cache_variables.fish
@@ -1,26 +1,26 @@
 function _fake_tide_cache_variables
     # pwd
     set_color -o $fake_tide_pwd_color_anchors | read -gx _fake_tide_color_anchors
-    set -gx _fake_tide_color_truncated_dirs "$(set_color $fake_tide_pwd_color_truncated_dirs)"
-    set -gx _fake_tide_reset_to_color_dirs (set_color normal -b $fake_tide_pwd_bg_color; set_color $fake_tide_pwd_color_dirs)
+    set -g _fake_tide_color_truncated_dirs "$(set_color $fake_tide_pwd_color_truncated_dirs)"
+    set -g _fake_tide_reset_to_color_dirs (set_color normal -b $fake_tide_pwd_bg_color; set_color $fake_tide_pwd_color_dirs)
 
     # git
     contains git $fake_tide_left_prompt_items $fake_tide_right_prompt_items &&
-        set -gx _fake_tide_location_color "$(set_color $fake_tide_git_color_branch)"
+        set -g _fake_tide_location_color "$(set_color $fake_tide_git_color_branch)"
 
     # private_mode
     if contains private_mode $fake_tide_left_prompt_items $fake_tide_right_prompt_items && test -n "$fish_private_mode"
-        set -gx _fake_tide_private_mode
+        set -g _fake_tide_private_mode true
     else
         set -e _fake_tide_private_mode
     end
 
     # Same-color-separator color
-    set -gx _fake_tide_color_separator_same_color "$(set_color $fake_tide_prompt_color_separator_same_color)"
+    set -g _fake_tide_color_separator_same_color "$(set_color $fake_tide_prompt_color_separator_same_color)"
 
     # two line prompt
     if contains newline $fake_tide_left_prompt_items
-        set_color $fake_tide_prompt_color_frame_and_connection -b normal | read -gx _fake_tide_prompt_and_frame_color
+        set_color $fake_tide_prompt_color_frame_and_connection -b normal | read -g _fake_tide_prompt_and_frame_color
     else
         set -e _fake_tide_prompt_and_frame_color
     end
@@ -34,7 +34,7 @@ function _fake_tide_cache_variables
 
     # item padding
     if test "$fake_tide_prompt_pad_items" = true
-        set -gx _fake_tide_pad ' '
+        set -g _fake_tide_pad ' '
     else
         set -e _fake_tide_pad
     end


### PR DESCRIPTION
#### Description

This avoids exporting these tide internal variables to global environment. Otherwise, the `env` command won't print correctly due to the escape sequences in these variables messing up the display.

#### Screenshots (if appropriate)

No visible change, except that the `_tide` variables are no longer in `env` output.

#### How Has This Been Tested

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I am ready to update the wiki accordingly. (seems unnecessary?)
- [ ] I have updated the tests accordingly. (will see if any tests fail)
