### PR TITLE
Tweak status item; adds cmd_duration_precise item

### DIFF
--- a/functions/_tide_item_cmd_duration_precise.fish
+++ b/functions/_tide_item_cmd_duration_precise.fish
@@ -1,0 +1,17 @@
+function _tide_item_cmd_duration_precise
+    test $CMD_DURATION -lt $tide_cmd_duration_threshold
+    and return 0
+
+    set d $CMD_DURATION
+    if test $d -ge 3600000
+        set out (math -s0 $d / 3600000)'h '(math -s0 $d / 60000 % 60)'m'
+    else if test $d -ge 60000
+        set out (math -s0 $d / 60000 % 60)'m '(math -s0 $d / 1000 % 60)'s'
+    else if test $d -ge 1000
+        set out (math -s$tide_cmd_duration_decimals $d / 1000 % 60)'s'
+    else
+        set out (math -s0 $d % 1000)'ms'
+    end
+
+    _tide_print_item cmd_duration $tide_cmd_duration_icon' ' "$out"
+end

--- a/functions/_tide_item_status.fish
+++ b/functions/_tide_item_status.fish
@@ -6,7 +6,7 @@ function _tide_item_status
 
     if contains "$_tide_pipestatus" $_tide_status_simple_failures
         contains character $_tide_left_items || tide_status_bg_color=$tide_status_bg_color_failure \
-            tide_status_color=$tide_status_color_failure _tide_print_item status $tide_status_icon_failure' ' 1
+            tide_status_color=$tide_status_color_failure _tide_print_item status $tide_status_icon_failure' ' "$_tide_pipestatus"
     else
         fish_status_to_signal $_tide_pipestatus | string replace SIG '' | string join '|' | read -l out
         test $_tide_status = 0 && _tide_print_item status $tide_status_icon' ' $out ||

--- a/functions/_tide_item_status.fish
+++ b/functions/_tide_item_status.fish
@@ -1,5 +1,5 @@
 function _tide_item_status
-    if string match -q 0 $_tide_pipestatus && not contains character $_tide_left_items
+    if string match -q 0 "$_tide_pipestatus" && not contains character $_tide_left_items
         _tide_print_item status $tide_status_icon
         return
     end

--- a/functions/_tide_item_status.fish
+++ b/functions/_tide_item_status.fish
@@ -1,15 +1,16 @@
 function _tide_item_status
-    if string match -qv 0 $_tide_pipestatus # If there is a failure anywhere in the pipestatus
-        if test "$_tide_pipestatus" = 1 # If simple failure
-            contains character $_tide_left_items || tide_status_bg_color=$tide_status_bg_color_failure \
-                tide_status_color=$tide_status_color_failure _tide_print_item status $tide_status_icon_failure' ' 1
-        else
-            fish_status_to_signal $_tide_pipestatus | string replace SIG '' | string join '|' | read -l out
-            test $_tide_status = 0 && _tide_print_item status $tide_status_icon' ' $out ||
-                tide_status_bg_color=$tide_status_bg_color_failure tide_status_color=$tide_status_color_failure \
-                    _tide_print_item status $tide_status_icon_failure' ' $out
-        end
-    else if not contains character $_tide_left_items
+    if string match -q 0 $_tide_pipestatus && not contains character $_tide_left_items
         _tide_print_item status $tide_status_icon
+        return
+    end
+
+    if contains "$_tide_pipestatus" $_tide_status_simple_failures
+        contains character $_tide_left_items || tide_status_bg_color=$tide_status_bg_color_failure \
+            tide_status_color=$tide_status_color_failure _tide_print_item status $tide_status_icon_failure' ' 1
+    else
+        fish_status_to_signal $_tide_pipestatus | string replace SIG '' | string join '|' | read -l out
+        test $_tide_status = 0 && _tide_print_item status $tide_status_icon' ' $out ||
+            tide_status_bg_color=$tide_status_bg_color_failure tide_status_color=$tide_status_color_failure \
+                _tide_print_item status $tide_status_icon_failure' ' $out
     end
 end

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -99,6 +99,7 @@ tide_status_bg_color 444444
 tide_status_bg_color_failure 444444
 tide_status_color $_tide_color_dark_green
 tide_status_color_failure D70000
+tide_status_simple_failures 1
 tide_terraform_bg_color 444444
 tide_terraform_color 844FBA
 tide_time_bg_color 444444

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -73,6 +73,7 @@ tide_status_bg_color black
 tide_status_bg_color_failure black
 tide_status_color green
 tide_status_color_failure red
+tide_status_simple_failures 1
 tide_terraform_bg_color black
 tide_terraform_color magenta
 tide_time_bg_color black

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -99,6 +99,7 @@ tide_status_bg_color normal
 tide_status_bg_color_failure normal
 tide_status_color $_tide_color_dark_green
 tide_status_color_failure D70000
+tide_status_simple_failures 1
 tide_terraform_bg_color normal
 tide_terraform_color 844FBA
 tide_time_bg_color normal

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -73,6 +73,7 @@ tide_status_bg_color normal
 tide_status_bg_color_failure normal
 tide_status_color green
 tide_status_color_failure red
+tide_status_simple_failures 1
 tide_terraform_bg_color normal
 tide_terraform_color magenta
 tide_time_bg_color normal

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -99,6 +99,7 @@ tide_status_bg_color 2E3436
 tide_status_bg_color_failure CC0000
 tide_status_color 4E9A06
 tide_status_color_failure FFFF00
+tide_status_simple_failures 1
 tide_terraform_bg_color 800080
 tide_terraform_color 000000
 tide_time_bg_color D3D7CF

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -73,6 +73,7 @@ tide_status_bg_color black
 tide_status_bg_color_failure red
 tide_status_color green
 tide_status_color_failure bryellow
+tide_status_simple_failures 1
 tide_terraform_bg_color magenta
 tide_terraform_color black
 tide_time_bg_color white

--- a/tests/_tide_item_cmd_duration_precise.test.fish
+++ b/tests/_tide_item_cmd_duration_precise.test.fish
@@ -13,8 +13,8 @@ end
 _cmd_duration 2000 3000 0 # Check:
 
 # formatting
-_cmd_duration  567    0000 3 # CHECK: 567ms
-_cmd_duration 4567    3000 2 # CHECK: 4.57s
-_cmd_duration 4567    3000 3 # CHECK: 4.567s
-_cmd_duration 456789  3000 3 # CHECK: 7m 36s
+_cmd_duration 0567 0000 3 # CHECK: 567ms
+_cmd_duration 4567 3000 2 # CHECK: 4.57s
+_cmd_duration 4567 3000 3 # CHECK: 4.567s
+_cmd_duration 456789 3000 3 # CHECK: 7m 36s
 _cmd_duration 4567000 3000 3 # CHECK: 1h 16m

--- a/tests/_tide_item_cmd_duration_precise.test.fish
+++ b/tests/_tide_item_cmd_duration_precise.test.fish
@@ -10,11 +10,11 @@ function _cmd_duration_precise -a duration threshold decimals
 end
 
 # threshold
-_cmd_duration 2000 3000 0 # Check:
+_cmd_duration_precise 2000 3000 0 # Check:
 
 # formatting
-_cmd_duration 0567 0000 3 # CHECK: 567ms
-_cmd_duration 4567 3000 2 # CHECK: 4.57s
-_cmd_duration 4567 3000 3 # CHECK: 4.567s
-_cmd_duration 456789 3000 3 # CHECK: 7m 36s
-_cmd_duration 4567000 3000 3 # CHECK: 1h 16m
+_cmd_duration_precise 0567 0000 3 # CHECK: 567ms
+_cmd_duration_precise 4567 3000 2 # CHECK: 4.57s
+_cmd_duration_precise 4567 3000 3 # CHECK: 4.567s
+_cmd_duration_precise 456789 3000 3 # CHECK: 7m 36s
+_cmd_duration_precise 4567000 3000 3 # CHECK: 1h 16m

--- a/tests/_tide_item_cmd_duration_precise.test.fish
+++ b/tests/_tide_item_cmd_duration_precise.test.fish
@@ -1,0 +1,20 @@
+# RUN: %fish %s
+_tide_parent_dirs
+
+function _cmd_duration_precise -a duration threshold decimals
+    set -lx CMD_DURATION $duration
+    set -lx tide_cmd_duration_threshold $threshold
+    set -lx tide_cmd_duration_decimals $decimals
+
+    _tide_decolor (_tide_item_cmd_duration)
+end
+
+# threshold
+_cmd_duration 2000 3000 0 # Check:
+
+# formatting
+_cmd_duration  567    0000 3 # CHECK: 567ms
+_cmd_duration 4567    3000 2 # CHECK: 4.57s
+_cmd_duration 4567    3000 3 # CHECK: 4.567s
+_cmd_duration 456789  3000 3 # CHECK: 7m 36s
+_cmd_duration 4567000 3000 3 # CHECK: 1h 16m

--- a/tests/_tide_item_cmd_duration_precise.test.fish
+++ b/tests/_tide_item_cmd_duration_precise.test.fish
@@ -6,14 +6,14 @@ function _cmd_duration_precise -a duration threshold decimals
     set -lx tide_cmd_duration_threshold $threshold
     set -lx tide_cmd_duration_decimals $decimals
 
-    _tide_decolor (_tide_item_cmd_duration)
+    _tide_decolor (_tide_item_cmd_duration_precise)
 end
 
 # threshold
 _cmd_duration_precise 2000 3000 0 # Check:
 
 # formatting
-_cmd_duration_precise 0567 0000 3 # CHECK: 567ms
+_cmd_duration_precise 567 0000 3 # CHECK: 567ms
 _cmd_duration_precise 4567 3000 2 # CHECK: 4.57s
 _cmd_duration_precise 4567 3000 3 # CHECK: 4.567s
 _cmd_duration_precise 456789 3000 3 # CHECK: 7m 36s

--- a/tests/_tide_item_status.test.fish
+++ b/tests/_tide_item_status.test.fish
@@ -7,6 +7,10 @@ function _status
     _tide_decolor (_tide_item_status)
 end
 
+function _return_status
+    return $argv
+end
+
 set -lx tide_status_icon ✔
 set -lx tide_status_icon_failure ✘
 
@@ -39,6 +43,43 @@ _status # CHECK:
 
 false
 _status # CHECK:
+
+true | false
+_status # CHECK: ✘ 0|1
+
+true | true
+_status # CHECK:
+
+false | true
+_status # CHECK: ✔ 1|0
+
+false | false
+_status # CHECK: ✘ 1|1
+
+# Check that not command works
+not true | false
+_status # CHECK: ✔ 0|1
+
+not false | true
+_status # CHECK: ✘ 1|0
+
+# With character and tide_status_simple_failures
+set -lx tide_status_simple_failures 2 4
+
+true
+_status # CHECK:
+
+false
+_status # CHECK: ✘ 1
+
+_return_status 2
+_status # CHECK:
+
+_return_status 4
+_status # CHECK:
+
+_return_status 4 | _return_status 1
+_status # CHECK: ✘ 4|1
 
 true | false
 _status # CHECK: ✘ 0|1


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Description

##### Tweaks status item
- Adds a new configuration option `tide_status_simple_failures` containing status codes that should be considered "simple failures"
  - Default value added to `configure/configs/*`
  - Tests added
- I plan to set this empty so all failures show a right-side indicator
- This lets you have both the character color changing and the indicator

##### Adds cmd_duration_precise item
- Almost the same as cmd_duration, but with this behavior:
  - when duration is > 1h, only show hours & minutes e.g. "1h 23m"
  - when duration is < 1h && > 1m, show minutes & seconds (no decimals) e.g. "1m 23s"
  - when duration is < 1m && > 1s, show seconds with decimals e.g. "1.23s"
  - when duration is < 1s, show milliseconds e.g. "123ms"
- Continues to obey tide_cmd_duration_threshold and tide_cmd_duration_decimals
- Tested

<!-- Describe your changes. -->

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### Motivation and Context
For the status item, I always want a failure indicator on the right side _and_ I want the character to change color (I don't always notice the color change, but it's nice to have.)

For cmd_duration_precise, I have two aims:
1. I like to see timings for all commands, but I don't want to see output like "0.427s" and would prefer "427ms"
2. I don't need to see the smaller time units when the total duration is quite large. e.g. when a command takes 9h 47m, i don't really care if it also 23s or 53s of that 47th minute. cmd_duration_precise makes all outputs ~5-ish chars long depending on the size of the numbers while still allowing you to see large and miniscule durations.

<!-- Why is this change required? What problem does it solve? -->

#### Screenshots (if appropriate)

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [ ] I have tested using **Linux**.
- [x] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [x] I am ready to update the wiki accordingly.
- [x] I have updated the tests accordingly.
