### PR TITLE
Add support for `nix shell` detection

### DIFF
--- a/functions/_tide_item_nix_shell.fish
+++ b/functions/_tide_item_nix_shell.fish
@@ -1,3 +1,13 @@
 function _tide_item_nix_shell
-    set -q IN_NIX_SHELL && _tide_print_item nix_shell $tide_nix_shell_icon' ' $IN_NIX_SHELL
+    if set -q IN_NIX_SHELL
+        _tide_print_item nix_shell $tide_nix_shell_icon' ' $IN_NIX_SHELL
+    else
+        for path_item in $PATH
+            if string match -q '/nix/store/*' $path_item
+                # if nix is ran with `nix shell` we cannot determine pure/impure
+                _tide_print_item nix_shell $tide_nix_shell_icon' ' unknown
+                return
+            end
+        end
+    end
 end

--- a/tests/_tide_item_nix_shell.test.fish
+++ b/tests/_tide_item_nix_shell.test.fish
@@ -17,3 +17,5 @@ set -lx IN_NIX_SHELL impure
 _nix_shell # CHECK:  impure
 
 set -e IN_NIX_SHELL
+set -lx PATH /nix/store/1234
+_nix_shell # CHECK:  unknown


### PR DESCRIPTION
#### Description

When using `nix shell`, the `IN_NIX_SHELL` variable is not set.

A common workaround is to check if `/nix/store/` is on the PATH.

#### Motivation and Context

`nix shell` does not set `$IN_NIX_SHELL`

Closes #542

#### Screenshots (if appropriate)

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [ ] I have tested using **Linux**.
- [x] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [x] I am ready to update the wiki accordingly.
- [x] I have updated the tests accordingly.
