### PR TITLE
Update _tide_item_rustc.fish

### DIFF
--- a/functions/_tide_item_rustc.fish
+++ b/functions/_tide_item_rustc.fish
@@ -1,6 +1,6 @@
 function _tide_item_rustc
     if path is $_tide_parent_dirs/Cargo.toml
-        rustc --version | string match -qr "(?<v>[\d.]+)"
+        rustup show active-toolchain | string match -qr "(?<v>^[\d.]+)"
         _tide_print_item rustc $tide_rustc_icon' ' $v
     end
 end


### PR DESCRIPTION
Fixes #444 by using `rustup show active-toolchain` instead of running `rustc`, which is downloaded on-demand.
