### PR TITLE
Update bun lockfile detection and use proper bun nerdfont icon

### DIFF
--- a/functions/_tide_item_bun.fish
+++ b/functions/_tide_item_bun.fish
@@ -1,5 +1,5 @@
 function _tide_item_bun
-    if path is $_tide_parent_dirs/bun.lockb
+    if path is $_tide_parent_dirs/bun.lockb $_tide_parent_dirs/bun.lock
         bun --version | string match -qr "(?<v>.*)"
         _tide_print_item bun $tide_bun_icon' ' $v
     end

--- a/functions/_tide_item_bun.fish
+++ b/functions/_tide_item_bun.fish
@@ -1,5 +1,5 @@
 function _tide_item_bun
-    if path is $_tide_parent_dirs/bun.lockb $_tide_parent_dirs/bun.lock
+    if path is $_tide_parent_dirs/bun.lock
         bun --version | string match -qr "(?<v>.*)"
         _tide_print_item bun $tide_bun_icon' ' $v
     end

--- a/functions/tide/configure/icons.fish
+++ b/functions/tide/configure/icons.fish
@@ -1,5 +1,5 @@
 tide_aws_icon  # Actual aws glyph is harder to see
-tide_bun_icon 󰳓
+tide_bun_icon 
 tide_character_icon ❯
 tide_character_vi_icon_default ❮
 tide_character_vi_icon_replace ▶

--- a/tests/_tide_item_bun.test.fish
+++ b/tests/_tide_item_bun.test.fish
@@ -8,20 +8,13 @@ end
 set -l tmpdir (mktemp -d)
 cd $tmpdir
 
-mock bun --version "echo 1.0.24"
-set -lx tide_bun_icon 󰳓
-
-_bun # CHECK:
-
-touch bun.lockb
-_bun # CHECK: 󰳓 1.0.24
-
 mock bun --version "echo 1.1.39"
-command rm bun.lockb
+set -lx tide_bun_icon 
 
 _bun # CHECK:
 
 touch bun.lock
-_bun # CHECK: 󰳓 1.1.39
+_bun # CHECK:  1.1.39
+command rm bun.lock
 
 command rm -r $tmpdir

--- a/tests/_tide_item_bun.test.fish
+++ b/tests/_tide_item_bun.test.fish
@@ -16,4 +16,12 @@ _bun # CHECK:
 touch bun.lockb
 _bun # CHECK: 󰳓 1.0.24
 
+mock bun --version "echo 1.1.39"
+command rm bun.lockb
+
+_bun # CHECK:
+
+touch bun.lock
+_bun # CHECK: 󰳓 1.1.39
+
 command rm -r $tmpdir


### PR DESCRIPTION
#### Description

Bun v1.1.39 introduced a new lockfile format `bun.lock`.
See: https://bun.com/blog/bun-lock-text-lockfile

#### Motivation and Context

Support for both `bun.lockb` and `bun.lock` format.

#### Screenshots (if appropriate)

None.

#### How Has This Been Tested

- [ ] I have tested using **Linux**.
- [x] I have tested using **MacOS**.

#### Checklist

- [x] I am ready to update the wiki accordingly. (no need to update)
- [x] I have updated the tests accordingly.
