### PR TITLE
fix: preserve color formatting when setting 'normal' background

### DIFF
--- a/functions/_tide_print_item.fish
+++ b/functions/_tide_print_item.fish
@@ -14,7 +14,8 @@ function _tide_print_item -a item
         echo -ns $tide_right_prompt_separator_diff_color
     end
 
-    v=tide_"$item"_color set_color $$v -b $item_bg_color
+    set_color -b $item_bg_color
+    v=tide_"$item"_color set_color $$v
 
     echo -ns $_tide_pad $argv[2..] $_tide_pad
 

--- a/functions/tide.fish
+++ b/functions/tide.fish
@@ -2,7 +2,7 @@ function tide --description 'Manage your Tide prompt'
     argparse --stop-nonopt v/version h/help -- $argv
 
     if set -q _flag_version
-        echo 'tide, version 6.2.0'
+        echo 'tide, version 6.2.1'
     else if set -q _flag_help
         _tide_help
     else if functions --query _tide_sub_$argv[1]


### PR DESCRIPTION
#### Description

From the fish docs
> Using the normal keyword will reset foreground, background, and all formatting back to default.

As `tide_"$item"_bg_color` is often set to "normal", it currently resets any formatting (e.g. `--bold`) that applied to the `tide_"$item"_color`.
Setting the background color separately and prior to the foreground color allows for this formatting to be preserved.

Before
<img width="754" height="154" alt="image" src="https://github.com/user-attachments/assets/d67269ad-d7bf-4f16-a5f9-9eb15c463e0a" />

After:
<img width="753" height="155" alt="image" src="https://github.com/user-attachments/assets/d093960f-6808-40a4-94fc-cf83d3354939" />
