### PR TITLE
Pass cached variables explicitly instead of through env vars

### DIFF
--- a/functions/_tide_cache_variables.fish
+++ b/functions/_tide_cache_variables.fish
@@ -1,17 +1,17 @@
 function _tide_cache_variables
     # Same-color-separator color
-    set_color $tide_prompt_color_separator_same_color | read -gx _tide_color_separator_same_color
+    set_color $tide_prompt_color_separator_same_color | read -g _tide_color_separator_same_color
 
     # git
-    contains git $_tide_left_items $_tide_right_items && set_color $tide_git_color_branch | read -gx _tide_location_color
+    contains git $_tide_left_items $_tide_right_items && set_color $tide_git_color_branch | read -g _tide_location_color
 
     # private_mode
     if contains private_mode $_tide_left_items $_tide_right_items && test -n "$fish_private_mode"
-        set -gx _tide_private_mode
+        set -g _tide_private_mode
     else
         set -e _tide_private_mode
     end
 
     # item padding
-    test "$tide_prompt_pad_items" = true && set -gx _tide_pad ' ' || set -e _tide_pad
+    test "$tide_prompt_pad_items" = true && set -g _tide_pad ' ' || set -e _tide_pad
 end

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -37,6 +37,10 @@ if contains newline $_tide_left_items # two line prompt initialization
     if test "$tide_prompt_transient_enabled" = true
         eval "
 function fish_prompt
+    set -lx _tide_color_separator_same_color \$_tide_color_separator_same_color
+    set -lx _tide_location_color \$_tide_location_color
+    set -lx _tide_private_mode \$_tide_private_mode
+    set -lx _tide_pad \$_tide_pad
     _tide_status=\$status _tide_pipestatus=\$pipestatus if not set -e _tide_repaint
         jobs -q && jobs -p | count | read -lx _tide_jobs
         $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
@@ -65,6 +69,12 @@ end"
     else
         eval "
 function fish_prompt
+
+    set -lx _tide_color_separator_same_color \$_tide_color_separator_same_color
+    set -lx _tide_location_color \$_tide_location_color
+    set -lx _tide_private_mode \$_tide_private_mode
+    set -lx _tide_pad \$_tide_pad
+
     _tide_status=\$status _tide_pipestatus=\$pipestatus if not set -e _tide_repaint
         jobs -q && jobs -p | count | read -lx _tide_jobs
         $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
@@ -96,6 +106,10 @@ else # one line prompt initialization
     if test "$tide_prompt_transient_enabled" = true
         eval "
 function fish_prompt
+    set -lx _tide_color_separator_same_color \$_tide_color_separator_same_color
+    set -lx _tide_location_color \$_tide_location_color
+    set -lx _tide_private_mode \$_tide_private_mode
+    set -lx _tide_pad \$_tide_pad
     set -lx _tide_status \$status
     _tide_pipestatus=\$pipestatus if not set -e _tide_repaint
         jobs -q && jobs -p | count | read -lx _tide_jobs
@@ -124,6 +138,10 @@ end"
     else
         eval "
 function fish_prompt
+    set -lx _tide_color_separator_same_color \$_tide_color_separator_same_color
+    set -lx _tide_location_color \$_tide_location_color
+    set -lx _tide_private_mode \$_tide_private_mode
+    set -lx _tide_pad \$_tide_pad
     _tide_status=\$status _tide_pipestatus=\$pipestatus if not set -e _tide_repaint
         jobs -q && jobs -p | count | read -lx _tide_jobs
         $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus

--- a/tests/_tide_item_git.test.fish
+++ b/tests/_tide_item_git.test.fish
@@ -1,5 +1,6 @@
 # RUN: %fish %s
 _tide_parent_dirs
+_tide_cache_variables
 
 function _git
     git $argv >/dev/null 2>&1


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Description

Pass cached variables explicitly instead of through env vars, instead of exposing them to all processes launched by the shell.

<!-- Describe your changes. -->

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

<!-- Why is this change required? What problem does it solve? -->

Closes #600 <!--- Please link to an open issue. -->

#### Screenshots (if appropriate)

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- Normal prompt (including git status) works
- Unit tests run

- [x] I have tested using **Linux**.
- [x] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.
