### PR TITLE
fix(node): should check for `node` command before attempting to run it

### DIFF
--- a/functions/_tide_item_node.fish
+++ b/functions/_tide_item_node.fish
@@ -1,5 +1,5 @@
 function _tide_item_node
-    if path is $_tide_parent_dirs/package.json
+    if path is $_tide_parent_dirs/package.json and (command -q node)
         node --version | string match -qr "v(?<v>.*)"
         _tide_print_item node $tide_node_icon' ' $v
     end


### PR DESCRIPTION
If you `cd` into a directory with a `package.json` and you don't have node installed, you get a bunch of errors. This should check whether the command exists first.