### PR TITLE
Handle empty fish_key_bindings in fish 4.3 (fixes #624)

### DIFF
--- a/functions/_tide_item_vi_mode.fish
+++ b/functions/_tide_item_vi_mode.fish
@@ -1,5 +1,5 @@
 function _tide_item_vi_mode
-    test "$fish_key_bindings" != fish_default_key_bindings && switch $fish_bind_mode
+    test -n "$fish_key_bindings" && test "$fish_key_bindings" != fish_default_key_bindings && switch $fish_bind_mode
         case default
             tide_vi_mode_bg_color=$tide_vi_mode_bg_color_default tide_vi_mode_color=$tide_vi_mode_color_default \
                 _tide_print_item vi_mode $tide_vi_mode_icon_default


### PR DESCRIPTION
Fish 4.3 seems to leave `$fish_key_bindings` empty by default, causing a false positive in the vi_mode check.

#### Description

Updated `_tide_item_vi_mode` to explicitly check for non-empty `$fish_key_bindings` first.

Closes #624.

#### How Has This Been Tested

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

- [ ] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.
