### PR TITLE
Handle empty fish_key_bindings in fish 4.3 (fixes #620, #622)

### DIFF
--- a/functions/_tide_item_character.fish
+++ b/functions/_tide_item_character.fish
@@ -3,7 +3,7 @@ function _tide_item_character
 
     set -q add_prefix || echo -ns ' '
 
-    test "$fish_key_bindings" = fish_default_key_bindings && echo -ns $tide_character_icon ||
+    test -n "$fish_key_bindings" && test "$fish_key_bindings" != fish_default_key_bindings &&
         switch $fish_bind_mode
             case insert
                 echo -ns $tide_character_icon
@@ -13,5 +13,6 @@ function _tide_item_character
                 echo -ns $tide_character_vi_icon_replace
             case visual
                 echo -ns $tide_character_vi_icon_visual
-        end
+        end ||
+        echo -ns $tide_character_icon
 end


### PR DESCRIPTION
Fish 4.3 seems to leave `$fish_key_bindings` empty by default, leading the check for default bindings in `_tide_item_character` to fail, and causing tide to render the vi-mode icons instead of the standard prompt character.

#### Description

Updated `_tide_item_character` to include a check for empty `$fish_key_bindings`.

Closes #620.
Closes #622.

#### How Has This Been Tested

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.
