### PR TITLE
Fix async prompt input lag on WSL by detaching background workers from stdin

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -41,7 +41,7 @@ function fish_prompt
         jobs -q && jobs -p | count | read -lx _tide_jobs
         $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
 set _tide_parent_dirs \$_tide_parent_dirs
-PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_2_line_prompt)\" &
+    PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_2_line_prompt)\" </dev/null &
         builtin disown
 
         command kill \$_tide_last_pid 2>/dev/null
@@ -69,7 +69,7 @@ function fish_prompt
         jobs -q && jobs -p | count | read -lx _tide_jobs
         $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
 set _tide_parent_dirs \$_tide_parent_dirs
-PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_2_line_prompt)\" &
+    PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_2_line_prompt)\" </dev/null &
         builtin disown
 
         command kill \$_tide_last_pid 2>/dev/null
@@ -101,7 +101,7 @@ function fish_prompt
         jobs -q && jobs -p | count | read -lx _tide_jobs
         $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
 set _tide_parent_dirs \$_tide_parent_dirs
-PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_1_line_prompt)\" &
+    PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_1_line_prompt)\" </dev/null &
         builtin disown
 
         command kill \$_tide_last_pid 2>/dev/null
@@ -128,7 +128,7 @@ function fish_prompt
         jobs -q && jobs -p | count | read -lx _tide_jobs
         $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
 set _tide_parent_dirs \$_tide_parent_dirs
-PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_1_line_prompt)\" &
+    PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_1_line_prompt)\" </dev/null &
         builtin disown
 
         command kill \$_tide_last_pid 2>/dev/null


### PR DESCRIPTION
#### Description

I ran into an issue on WSL where Tide becomes hard to use while async git status is still loading. During that time, some keystrokes seem to get lost or delayed, and then everything goes back to normal as soon as git info appears.

This change adds `</dev/null` to all background prompt worker launches in `fish_prompt.fish`, so those async worker processes are fully detached from stdin.

I want to be transparent: I’m not 100% sure about the exact low-level reason this fixes it, but in my case it consistently solved the problem.

#### Motivation and Context

The problem was especially visible in large repos on WSL2 (`/mnt/c/...`) where git status takes several seconds. The whole point of async prompt rendering is to keep the shell responsive during that time, and that wasn’t happening for me.

I originally found this issue (and this possible fix) with AI assistance, so this PR should definitely be reviewed by someone who knows this part of Tide/fish internals better before merging.

Closes #643

#### Screenshots (if appropriate)

N/A

#### How Has This Been Tested

I tested manually on my setup:
- WSL2
- large git repo on `/mnt/c`
- repeatedly `cd` into repo and type immediately while git segment is still loading

Before this change, typing felt laggy and some keys were missed.  
After this change, prompt interaction stayed smooth while git status loaded in the background.

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

- [ ] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.