### PR TITLE
Add vbattery and hbattery prompt items

### DIFF
--- a/functions/_tide_item_hbattery.fish
+++ b/functions/_tide_item_hbattery.fish
@@ -1,0 +1,49 @@
+function _tide_item_hbattery
+    switch $tide_battery_method
+        case termux
+            set -l termux_bat_out (termux-battery-status)
+            set -f bat_capacity (string match -rg 'percentage": ([0-9]*)' $termux_bat_out)
+            set -f bat_status (string match -rg '"status": "([^"]*)"' $termux_bat_out)
+        case sysfs
+            if set -q tide_battery_sysfs_name
+                set -f bat_capacity (cat /sys/class/power_supply/$tide_battery_sysfs_name/capacity)
+                set -f bat_status (cat /sys/class/power_supply/$tide_battery_sysfs_name/status)
+            else
+                set -l battery_name /sys/class/power_supply/BAT*
+                if count $battery_name >/dev/null
+                    set -f bat_capacity (cat $battery_name/capacity)[1]
+                    set -f bat_status (cat $battery_name/status)[1]
+                end
+            end
+        case '*'
+            set -l upower_out (upower -b)
+            set -f bat_capacity (string match -rg 'percentage: *([0-9]*)' $upower_out)
+            set -f bat_status (string match -rg 'state: *(.*)' $upower_out)
+    end
+
+    test -n "$bat_capacity" || return
+
+    #                      0-19 20-39 40-59 60-79 80-99 100
+    set -f battery_symbols '' '' '' '' '' ''
+
+    switch (string lower $bat_status)
+        case 'not charging' 'fully charged' fully-charged
+            _tide_print_item hbattery ''
+            return
+        case discharging
+            if test $bat_capacity -lt $tide_battery_critical_threshold
+                set -fx tide_battery_color $tide_battery_color_critical
+            else if test $bat_capacity -lt $tide_battery_low_threshold
+                set -fx tide_battery_color $tide_battery_color_low
+            end
+    end
+
+    set -l symbol_index (math -s0 "$bat_capacity / 20 + 1")
+    set -l battery_symbol $battery_symbols[$symbol_index]
+
+    if string match charging (string lower $bat_status) -q
+        _tide_print_item hbattery "$battery_symbol 󰉁"
+    else
+        _tide_print_item hbattery $battery_symbol
+    end
+end

--- a/functions/_tide_item_vbattery.fish
+++ b/functions/_tide_item_vbattery.fish
@@ -1,0 +1,49 @@
+function _tide_item_vbattery
+    switch $tide_battery_method
+        case termux
+            set -l termux_bat_out (termux-battery-status)
+            set -f bat_capacity (string match -rg 'percentage": ([0-9]*)' $termux_bat_out)
+            set -f bat_status (string match -rg '"status": "([^"]*)"' $termux_bat_out)
+        case sysfs
+            if set -q tide_battery_sysfs_name
+                set -f bat_capacity (cat /sys/class/power_supply/$tide_battery_sysfs_name/capacity)
+                set -f bat_status (cat /sys/class/power_supply/$tide_battery_sysfs_name/status)
+            else
+                set -l battery_name /sys/class/power_supply/BAT*
+                if count $battery_name >/dev/null
+                    set -f bat_capacity (cat $battery_name/capacity)[1]
+                    set -f bat_status (cat $battery_name/status)[1]
+                end
+            end
+        case '*'
+            set -l upower_out (upower -b)
+            set -f bat_capacity (string match -rg 'percentage: *([0-9]*)' $upower_out)
+            set -f bat_status (string match -rg 'state: *(.*)' $upower_out)
+    end
+
+    test -n "$bat_capacity" || return
+
+    switch (string lower $bat_status)
+        case 'not charging' 'fully charged'
+            _tide_print_item vbattery '󰁹'
+            return
+        case charging
+            #                        0-4 5-14 15-24 25-34 35-44 45-54 55-64 65-74 75-84 85-94 95-100
+            set -f battery_symbols '󰢟' '󰢜' '󰂆' '󰂇' '󰂈' '󰢝' '󰂉' '󰢞' '󰂊' '󰂋' '󰂅'
+        case discharging
+            set -f battery_symbols '󰂎' '󰁺' '󰁻' '󰁼' '󰁽' '󰁾' '󰁿' '󰂀' '󰂁' '󰂂' '󰁹'
+            if test $bat_capacity -lt $tide_battery_critical_threshold
+                set -fx tide_battery_color $tide_battery_color_critical
+            else if test $bat_capacity -lt $tide_battery_low_threshold
+                set -fx tide_battery_color $tide_battery_color_low
+            end
+        case '*'
+            _tide_print_item vbattery '󰂑'
+            return
+    end
+
+    set -l symbol_index (math -s0 -m round "$bat_capacity / 10 + 1")
+    set -l battery_symbol $battery_symbols[$symbol_index]
+
+    _tide_print_item vbattery $battery_symbol
+end

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -1,5 +1,14 @@
 tide_aws_bg_color 444444
 tide_aws_color FF9900
+tide_battery_color_critical D70000
+tide_battery_color_low C4A000
+tide_battery_critical_threshold 15
+tide_battery_low_threshold 40
+tide_battery_method
+tide_hbattery_bg_color 444444
+tide_hbattery_color FFFFFF
+tide_vbattery_bg_color 444444
+tide_vbattery_color FFFFFF
 tide_bun_bg_color 14151A
 tide_bun_color FBF0DF
 tide_character_color $_tide_color_green

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -1,5 +1,14 @@
 tide_aws_bg_color black
 tide_aws_color yellow
+tide_battery_color_critical brred
+tide_battery_color_low bryellow
+tide_battery_critical_threshold 15
+tide_battery_low_threshold 40
+tide_battery_method
+tide_hbattery_bg_color black
+tide_hbattery_color normal
+tide_vbattery_bg_color black
+tide_vbattery_color normal
 tide_bun_bg_color black
 tide_bun_color white
 tide_character_color brgreen

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -1,5 +1,14 @@
 tide_aws_bg_color normal
 tide_aws_color FF9900
+tide_battery_color_critical D70000
+tide_battery_color_low C4A000
+tide_battery_critical_threshold 15
+tide_battery_low_threshold 40
+tide_battery_method
+tide_hbattery_bg_color normal
+tide_hbattery_color normal
+tide_vbattery_bg_color normal
+tide_vbattery_color normal
 tide_bun_bg_color normal
 tide_bun_color FBF0DF
 tide_character_color $_tide_color_green

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -1,5 +1,14 @@
 tide_aws_bg_color normal
 tide_aws_color yellow
+tide_battery_color_critical brred
+tide_battery_color_low bryellow
+tide_battery_critical_threshold 15
+tide_battery_low_threshold 40
+tide_battery_method
+tide_hbattery_bg_color normal
+tide_hbattery_color normal
+tide_vbattery_bg_color normal
+tide_vbattery_color normal
 tide_bun_bg_color normal
 tide_bun_color white
 tide_character_color brgreen

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -1,5 +1,14 @@
 tide_aws_bg_color FF9900
 tide_aws_color 232F3E
+tide_battery_color_critical D70000
+tide_battery_color_low C4A000
+tide_battery_critical_threshold 15
+tide_battery_low_threshold 40
+tide_battery_method
+tide_hbattery_bg_color 444444
+tide_hbattery_color FFFFFF
+tide_vbattery_bg_color 444444
+tide_vbattery_color FFFFFF
 tide_bun_bg_color FBF0DF
 tide_bun_color 14151A
 tide_character_color $_tide_color_green

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -1,5 +1,14 @@
 tide_aws_bg_color yellow
 tide_aws_color brblack
+tide_battery_color_critical brred
+tide_battery_color_low bryellow
+tide_battery_critical_threshold 15
+tide_battery_low_threshold 40
+tide_battery_method
+tide_hbattery_bg_color brblack
+tide_hbattery_color white
+tide_vbattery_bg_color brblack
+tide_vbattery_color white
 tide_bun_bg_color white
 tide_bun_color black
 tide_character_color brgreen

--- a/tests/_tide_item_battery.test.fish
+++ b/tests/_tide_item_battery.test.fish
@@ -1,0 +1,143 @@
+# RUN: %fish %s
+source (status dirname)/../functions/_tide_parent_dirs.fish
+source (status dirname)/../functions/_tide_print_item.fish
+source (status dirname)/../functions/_tide_item_vbattery.fish
+source (status dirname)/../functions/_tide_item_hbattery.fish
+
+function _tide_decolor
+    string replace --all -r '\e(\[[\d;]*|\(B\e\[)m(\co)?' '' "$argv"
+end
+
+set -g _tide_side right
+set -g _tide_pad ''
+set -g tide_right_prompt_separator_diff_color ''
+set -g tide_right_prompt_separator_same_color ''
+set -g tide_right_prompt_prefix ''
+
+_tide_parent_dirs
+
+set -lx tide_battery_color_critical red
+set -lx tide_battery_color_low yellow
+set -lx tide_battery_critical_threshold 15
+set -lx tide_battery_low_threshold 40
+set -lx tide_battery_method ''
+
+# ── vbattery ──────────────────────────────────────────────────────────────────
+
+function _vbattery
+    _tide_decolor (_tide_item_vbattery)
+end
+
+set -lx tide_vbattery_bg_color normal
+set -lx tide_vbattery_color normal
+
+function upower
+    echo 'No battery found'
+end
+_vbattery # CHECK:
+
+function upower
+    echo 'percentage:   50'
+    echo 'state:      discharging'
+end
+_vbattery # CHECK: 󰁾
+
+function upower
+    echo 'percentage:   20'
+    echo 'state:      discharging'
+end
+_vbattery # CHECK: 󰁻
+
+function upower
+    echo 'percentage:   10'
+    echo 'state:      discharging'
+end
+_vbattery # CHECK: 󰁺
+
+function upower
+    echo 'percentage:   50'
+    echo 'state:      charging'
+end
+_vbattery # CHECK: 󰢝
+
+function upower
+    echo 'percentage:   100'
+    echo 'state:      fully charged'
+end
+_vbattery # CHECK: 󰁹
+
+function upower
+    echo 'percentage:   100'
+    echo 'state:      not charging'
+end
+_vbattery # CHECK: 󰁹
+
+function upower
+    echo 'percentage:   50'
+    echo 'state:      unknown'
+end
+_vbattery # CHECK: 󰂑
+
+set -lx tide_battery_method termux
+function termux-battery-status
+    echo '{"percentage": 75, "status": "CHARGING"}'
+end
+_vbattery # CHECK: 󰂊
+
+# ── hbattery ──────────────────────────────────────────────────────────────────
+
+set -lx tide_battery_method ''
+
+function _hbattery
+    _tide_decolor (_tide_item_hbattery)
+end
+
+set -lx tide_hbattery_bg_color normal
+set -lx tide_hbattery_color normal
+
+function upower
+    echo 'No battery found'
+end
+_hbattery # CHECK:
+
+function upower
+    echo 'percentage:   10'
+    echo 'state:      discharging'
+end
+_hbattery # CHECK: 
+
+function upower
+    echo 'percentage:   30'
+    echo 'state:      discharging'
+end
+_hbattery # CHECK: 
+
+function upower
+    echo 'percentage:   60'
+    echo 'state:      discharging'
+end
+_hbattery # CHECK: 
+
+function upower
+    echo 'percentage:   80'
+    echo 'state:      charging'
+end
+_hbattery # CHECK:  󰉁
+
+function upower
+    echo 'percentage:   80'
+    echo 'state:      discharging'
+end
+_hbattery # CHECK: 
+
+function upower
+    echo 'percentage:   100'
+    echo 'state:      fully charged'
+end
+_hbattery # CHECK: 
+
+function upower
+    echo 'percentage:   100'
+    echo 'state:      not charging'
+end
+_hbattery # CHECK: 


### PR DESCRIPTION
Two new items for displaying battery status:
  - `vbattery`: font icons with 11 charge levels, separate charging/discharging icon sets and color alerts for low/critical
  - `hbattery`: block bar with 5 levels using integer bucketing

Both items share common configuration under `tide_battery_*` (method, thresholds, critical/low colors) while each has its own `tide_<item>_bg_color` and `tide_<item>_color`.

Supported backends: upower (default), sysfs, termux.

<!-- Provide a general summary of your changes in the Title above. -->

#### Description

<!-- Describe your changes. -->

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Closes #294

#### Screenshots (if appropriate)
<img width="417" height="116" alt="obrázok" src="https://github.com/user-attachments/assets/8a3e8ece-d5de-4319-aca3-2acf5c13f2dc" />


#### How Has This Been Tested

Added both items to left prompt items on a laptop running on battery. Verified visually. Tested via `littlecheck.py`.

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [x] I am ready to update the wiki accordingly.
- [x] I have updated the tests accordingly.
