### PR TITLE
Add ascii-friendly option.

### DIFF
--- a/functions/_tide_sub_configure.fish
+++ b/functions/_tide_sub_configure.fish
@@ -36,7 +36,7 @@ function _tide_sub_configure
     set -g fake_lines $LINES
 
     set -g _tide_selected_option
-    _next_choice all/style
+    _next_choice all/ascii_friendly
 end
 
 function _next_choice -a nextChoice
@@ -104,7 +104,7 @@ function _tide_menu -a func
                 set -q _flag_no_restart && continue
                 set -e _tide_symbol_list
                 set -e _tide_option_list
-                _next_choice all/style
+                _next_choice all/ascii_friendly
                 break
             case q
                 _tide_exit_configure

--- a/functions/tide/configure/choices/all/ascii_friendly.fish
+++ b/functions/tide/configure/choices/all/ascii_friendly.fish
@@ -1,0 +1,33 @@
+function ascii_friendly
+    set -e _tide_ascii_friendly # Clear on restart
+
+    _tide_title 'ASCII-Friendly Prompt'
+
+    echo
+    echo 'Choose Yes if your terminal does not support Nerd Fonts or powerline glyphs.'
+    echo
+
+    _tide_option 1 No
+    _tide_option 2 Yes
+
+    _tide_menu (status function) --no-restart
+    switch $_tide_selected_option
+        case Yes
+            set -g _tide_ascii_friendly true
+    end
+    _next_choice all/style
+end
+
+function _tide_apply_ascii_overrides
+    # Replace powerline glyphs with ASCII equivalents
+    set -g fake_tide_left_prompt_separator_diff_color '>'
+    set -g fake_tide_right_prompt_separator_diff_color '<'
+    set -g fake_tide_left_prompt_separator_same_color '|'
+    set -g fake_tide_right_prompt_separator_same_color '|'
+    set -g fake_tide_left_prompt_suffix '>'
+    set -g fake_tide_right_prompt_prefix '<'
+    set -g fake_tide_left_prompt_prefix '['
+    set -g fake_tide_right_prompt_suffix ']'
+    set -g fake_tide_prompt_icon_connection -
+    _disable_icons
+end

--- a/functions/tide/configure/choices/all/icons.fish
+++ b/functions/tide/configure/choices/all/icons.fish
@@ -1,4 +1,10 @@
 function icons
+    if set -q _tide_ascii_friendly
+        _disable_icons
+        _next_choice all/transient
+        return
+    end
+
     _tide_title Icons
 
     _tide_option 1 'Few icons'

--- a/functions/tide/configure/choices/all/prompt_colors.fish
+++ b/functions/tide/configure/choices/all/prompt_colors.fish
@@ -7,12 +7,14 @@ function prompt_colors
     _tide_option 2 '16 colors'
     _load_config "$_tide_configure_style"_16color
     set -g _tide_16color true
+    test "$_tide_configure_style" != lean && set -q _tide_ascii_friendly && _tide_apply_ascii_overrides
     _tide_display_prompt
 
     _tide_menu (status function)
     switch $_tide_selected_option
         case 'True color'
             _load_config "$_tide_configure_style"
+            test "$_tide_configure_style" != lean && set -q _tide_ascii_friendly && _tide_apply_ascii_overrides
             set -e _tide_16color
             switch $_tide_configure_style
                 case lean rainbow

--- a/functions/tide/configure/choices/all/prompt_connection.fish
+++ b/functions/tide/configure/choices/all/prompt_connection.fish
@@ -1,4 +1,15 @@
 function prompt_connection
+    if set -q _tide_ascii_friendly
+        set -g fake_tide_prompt_icon_connection -
+        switch $_tide_configure_style
+            case lean
+                _next_choice all/prompt_connection_andor_frame_color
+            case classic rainbow
+                _next_choice powerline/powerline_right_prompt_frame
+        end
+        return
+    end
+
     _tide_title 'Prompt Connection'
 
     _tide_option 1 Disconnected

--- a/functions/tide/configure/choices/all/style.fish
+++ b/functions/tide/configure/choices/all/style.fish
@@ -9,10 +9,12 @@ function style
 
     _tide_option 2 Classic
     _load_config classic
+    set -q _tide_ascii_friendly && _tide_apply_ascii_overrides
     _tide_display_prompt
 
     _tide_option 3 Rainbow
     _load_config rainbow
+    set -q _tide_ascii_friendly && _tide_apply_ascii_overrides
     _tide_display_prompt
 
     _tide_menu (status function) --no-restart
@@ -22,9 +24,11 @@ function style
             set -g _tide_configure_style lean
         case Classic
             _load_config classic
+            set -q _tide_ascii_friendly && _tide_apply_ascii_overrides
             set -g _tide_configure_style classic
         case Rainbow
             _load_config rainbow
+            set -q _tide_ascii_friendly && _tide_apply_ascii_overrides
             set -g _tide_configure_style rainbow
     end
     _next_choice all/prompt_colors
@@ -33,4 +37,9 @@ end
 function _load_config -a name
     string replace -r '^' 'set -g fake_' <(status dirname)/../../icons.fish | source
     string replace -r '^' 'set -g fake_' <(status dirname)/../../configs/$name.fish | source
+    if set -q _tide_ascii_friendly
+        set -g fake_tide_character_icon '$'
+        set -g fake_tide_pwd_icon_unwritable '!'
+        set -g fake_tide_private_mode_icon P
+    end
 end

--- a/functions/tide/configure/choices/classic/classic_prompt_separators.fish
+++ b/functions/tide/configure/choices/classic/classic_prompt_separators.fish
@@ -1,4 +1,10 @@
 function classic_prompt_separators
+    if set -q _tide_ascii_friendly
+        _tide_apply_ascii_overrides
+        _next_choice powerline/powerline_prompt_heads
+        return
+    end
+
     _tide_title 'Prompt Separators'
 
     _tide_option 1 Angled

--- a/functions/tide/configure/choices/powerline/powerline_prompt_heads.fish
+++ b/functions/tide/configure/choices/powerline/powerline_prompt_heads.fish
@@ -1,4 +1,10 @@
 function powerline_prompt_heads
+    if set -q _tide_ascii_friendly
+        _tide_apply_ascii_overrides
+        _next_choice powerline/powerline_prompt_tails
+        return
+    end
+
     _tide_title 'Prompt Heads'
 
     _tide_option 1 Sharp

--- a/functions/tide/configure/choices/powerline/powerline_prompt_tails.fish
+++ b/functions/tide/configure/choices/powerline/powerline_prompt_tails.fish
@@ -1,4 +1,10 @@
 function powerline_prompt_tails
+    if set -q _tide_ascii_friendly
+        _tide_apply_ascii_overrides
+        _next_choice powerline/powerline_prompt_style
+        return
+    end
+
     _tide_title 'Prompt Tails'
 
     _tide_option 1 Flat

--- a/functions/tide/configure/choices/rainbow/rainbow_prompt_separators.fish
+++ b/functions/tide/configure/choices/rainbow/rainbow_prompt_separators.fish
@@ -1,4 +1,10 @@
 function rainbow_prompt_separators
+    if set -q _tide_ascii_friendly
+        _tide_apply_ascii_overrides
+        _next_choice powerline/powerline_prompt_heads
+        return
+    end
+
     _tide_title 'Prompt Separators'
 
     _tide_option 1 Angled


### PR DESCRIPTION
#### Description
Add an "ASCII-Friendly Prompt" option as the first step of the tide configure wizard. When selected, it replaces all Nerd Font glyphs and powerline characters with plain ASCII equivalents throughout the configuration flow, and skips glyph-dependent steps (icons, prompt separators, heads, tails).

#### Motivation and Context
Tide's default configuration assumes Nerd Fonts are installed and the terminal supports powerline glyphs. Users on minimal setups - SSH sessions, TTYs, CI environments, or terminals without patched fonts - would previously get a prompt full of broken/missing characters with no easy way to configure around it.

Closes #648 

#### Screenshots (if appropriate)
<img width="728" height="495" alt="obrázok" src="https://github.com/user-attachments/assets/596d3a6b-9a8b-4756-bcdb-84715e8dedbf" />


#### How Has This Been Tested

Installed via `fisher` and tried to configure various options.

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

- [x] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.
