### PR TITLE
Go item: detect go.work for Go workspace support

### DIFF
--- a/functions/_tide_item_go.fish
+++ b/functions/_tide_item_go.fish
@@ -1,5 +1,5 @@
 function _tide_item_go
-    if path is $_tide_parent_dirs/go.mod
+    if path is $_tide_parent_dirs/go.mod $_tide_parent_dirs/go.work
         go version | string match -qr "(?<v>[\d.]+)"
         _tide_print_item go $tide_go_icon' ' $v
     end

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -79,7 +79,7 @@ tide_pwd_bg_color 444444
 tide_pwd_color_anchors $_tide_color_light_blue
 tide_pwd_color_dirs $_tide_color_dark_blue
 tide_pwd_color_truncated_dirs 8787AF
-tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform bun.lock Cargo.toml composer.json CVS go.mod package.json build.zig
+tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform bun.lock Cargo.toml composer.json CVS go.mod go.work package.json build.zig
 tide_python_bg_color 444444
 tide_python_color 00AFAF
 tide_right_prompt_frame_enabled true

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -79,7 +79,7 @@ tide_pwd_bg_color normal
 tide_pwd_color_anchors $_tide_color_light_blue
 tide_pwd_color_dirs $_tide_color_dark_blue
 tide_pwd_color_truncated_dirs 8787AF
-tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform bun.lock Cargo.toml composer.json CVS go.mod package.json build.zig
+tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform bun.lock Cargo.toml composer.json CVS go.mod go.work package.json build.zig
 tide_python_bg_color normal
 tide_python_color 00AFAF
 tide_right_prompt_frame_enabled false

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -79,7 +79,7 @@ tide_pwd_bg_color 3465A4
 tide_pwd_color_anchors E4E4E4
 tide_pwd_color_dirs E4E4E4
 tide_pwd_color_truncated_dirs BCBCBC
-tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform bun.lock Cargo.toml composer.json CVS go.mod package.json build.zig
+tide_pwd_markers .bzr .citc .git .hg .node-version .python-version .ruby-version .shorten_folder_marker .svn .terraform bun.lock Cargo.toml composer.json CVS go.mod go.work package.json build.zig
 tide_python_bg_color 444444
 tide_python_color 00AFAF
 tide_right_prompt_frame_enabled true

--- a/tests/_tide_item_go.test.fish
+++ b/tests/_tide_item_go.test.fish
@@ -16,4 +16,10 @@ _go # CHECK:
 touch go.mod
 _go # CHECK:  1.16.5
 
+command rm -f go.mod
+_go # CHECK:
+
+touch go.work
+_go # CHECK:  1.16.5
+
 command rm -r $goDir


### PR DESCRIPTION
Currently the Go prompt item only checks for go.mod files. Go has
supported multi-module workspaces via go.work files since Go 1.18.

Add go.work to the path check so the Go version indicator is shown
in Go workspace roots that don't have a top-level go.mod.

Closes #660
