### PR TITLE
fix issues with tide configure --auto causing blank initial prompts

### DIFF
--- a/functions/_tide_sub_configure.fish
+++ b/functions/_tide_sub_configure.fish
@@ -56,14 +56,14 @@ function _tide_title -a text
     set -g _tide_configure_first_option_after_title
 end
 
-function _tide_option -a symbol text
+function _tide_option -a symbol text color
     set -ga _tide_symbol_list $symbol
     set -ga _tide_option_list $text
 
     if not set -q _flag_auto
         set -g _tide_configure_first_prompt_after_option
 
-        set_color -o
+        set_color -o $color
         set -e _tide_configure_first_option_after_title || echo
         echo "($symbol) $text"
         set_color normal

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -9,6 +9,7 @@ source (functions --details _tide_pwd)
 
 set -l prompt_var _tide_prompt_$fish_pid
 set -U $prompt_var # Set var here so if we erase $prompt_var, bg job won't set a uvar
+set -e _tide_repaint # Clear any repaint flag triggered by the set -U above
 
 set_color normal | read -l color_normal
 status fish-path | read -l fish_path

--- a/functions/tide/configure/choices/all/finish.fish
+++ b/functions/tide/configure/choices/all/finish.fish
@@ -1,21 +1,23 @@
 function finish
     _tide_title Finish
 
-    echo
+    set -q _flag_auto || echo
     set_color red
     _tide_option y 'Overwrite your current tide config'
     set_color normal
-    echo
+    set -q _flag_auto || echo
 
     _tide_option p 'Exit and print the config you just generated'
-    echo
+    set -q _flag_auto || echo
 
     _tide_menu (status function)
     switch $_tide_selected_option
         case 'Overwrite your current tide config'
             _tide_finish
-            command -q clear && clear
-            set -q _flag_auto || _tide_print_configure_current_options
+            set -q _flag_auto || begin
+                command -q clear && clear
+                _tide_print_configure_current_options
+            end
         case 'Exit and print the config you just generated'
             _tide_exit_configure
             command -q clear && clear

--- a/functions/tide/configure/choices/all/finish.fish
+++ b/functions/tide/configure/choices/all/finish.fish
@@ -2,9 +2,7 @@ function finish
     _tide_title Finish
 
     set -q _flag_auto || echo
-    set_color red
-    _tide_option y 'Overwrite your current tide config'
-    set_color normal
+    _tide_option y 'Overwrite your current tide config' red
     set -q _flag_auto || echo
 
     _tide_option p 'Exit and print the config you just generated'


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Description

Add some guarding on `tide configure --auto` to improve behavior when you put said command in your `config.fish`
<!-- Describe your changes. -->

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### Motivation and Context

You get a blank terminal with no prompt when you ssh in
<!-- Why is this change required? What problem does it solve? -->


#### Screenshots (if appropriate)

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [x] I am ready to update the wiki accordingly.
- [x] I have updated the tests accordingly.
